### PR TITLE
Allow using namespaces in schemas

### DIFF
--- a/spec/avro_spec.rb
+++ b/spec/avro_spec.rb
@@ -123,4 +123,86 @@ describe AvroTurf do
 
     expect(avro.decode(encoded_data)).to eq "hello, world"
   end
+
+  it "allows using namespaces in schemas" do
+    FileUtils.mkdir_p("spec/schemas/test/people")
+
+    File.open("spec/schemas/test/people/person.avsc", "w") do |f|
+      f.write <<-AVSC
+        {
+          "name": "person",
+          "namespace": "test.people",
+          "type": "record",
+          "fields": [
+            {
+              "type": "string",
+              "name": "full_name"
+            },
+            {
+              "name": "address",
+              "type": "test.people.address"
+            }
+          ]
+        }
+      AVSC
+    end
+
+    File.open("spec/schemas/test/people/address.avsc", "w") do |f|
+      f.write <<-AVSC
+        {
+          "name": "address",
+          "namespace": "test.people",
+          "type": "record",
+          "fields": [
+            {
+              "type": "string",
+              "name": "street"
+            },
+            {
+              "type": "string",
+              "name": "city"
+            }
+          ]
+        }
+      AVSC
+    end
+
+    data = {
+      "full_name" => "John Doe",
+      "address" => {
+        "street" => "Market st. 989",
+        "city" => "San Francisco"
+      }
+    }
+
+    encoded_data = avro.encode(data, schema_name: "test.people.person")
+
+    expect(avro.decode(encoded_data, schema_name: "test.people.person")).to eq(data)
+  end
+
+  it "raises AvroTurf::SchemaError if the schema's namespace doesn't match the file location" do
+    FileUtils.mkdir_p("spec/schemas/test/people")
+
+    File.open("spec/schemas/test/people/person.avsc", "w") do |f|
+      f.write <<-AVSC
+        {
+          "name": "person",
+          "namespace": "yoyoyo.nanana",
+          "type": "record",
+          "fields": [
+            {
+              "type": "string",
+              "name": "full_name"
+            }
+          ]
+        }
+      AVSC
+    end
+
+    data = { "full_name" => "John Doe" }
+
+    expect {
+      avro.encode(data, schema_name: "test.people.person")
+    }.to raise_error(AvroTurf::SchemaError, "expected schema `spec/schemas/test/people/person.avsc' to define type `test.people.person'")
+  end
 end


### PR DESCRIPTION
Each part of a namespace is mapped to a directory on disk, so the type `example.blog.Post` would be stored at `example/blog/Post.avsc`.