### PR TITLE
Allow eager loading schemas

### DIFF
--- a/lib/avro_turf.rb
+++ b/lib/avro_turf.rb
@@ -71,4 +71,9 @@ class AvroTurf
     dr = Avro::DataFile::Reader.new(stream, reader)
     dr.first
   end
+
+  # Loads all schema definition files in the `schemas_dir`.
+  def load_schemas!
+    @schema_store.load_schemas!
+  end
 end

--- a/lib/avro_turf/schema_store.rb
+++ b/lib/avro_turf/schema_store.rb
@@ -39,4 +39,20 @@ class AvroTurf::SchemaStore
   rescue Errno::ENOENT
     raise AvroTurf::SchemaNotFoundError, "could not find Avro schema at `#{schema_path}'"
   end
+
+  # Loads all schema definition files in the `schemas_dir`.
+  def load_schemas!
+    pattern = [@path, "**", "*.avsc"].join("/")
+
+    Dir.glob(pattern) do |schema_path|
+      # Remove the path prefix.
+      schema_path.sub!(/^\/#{@path}\//, "")
+
+      # Replace `/` with `.` and chop off the file extension.
+      schema_name = File.basename(schema_path.tr("/", "."), ".avsc")
+
+      # Load and cache the schema.
+      find(schema_name)
+    end
+  end
 end

--- a/spec/schema_store_spec.rb
+++ b/spec/schema_store_spec.rb
@@ -167,4 +167,56 @@ describe AvroTurf::SchemaStore do
       expect(schema.fullname).to eq "person"
     end
   end
+
+  describe "#load_schemas!" do
+    it "loads schemas defined in the `schemas_path` directory" do
+      define_schema "person.avsc", <<-AVSC
+        {
+          "name": "person",
+          "type": "record",
+          "fields": [
+            {
+              "type": "string",
+              "name": "full_name"
+            }
+          ]
+        }
+      AVSC
+
+      # Warm the schema cache.
+      store.load_schemas!
+
+      # Force a failure if the schema file is read again.
+      FileUtils.rm("spec/schemas/person.avsc")
+
+      schema = store.find("person")
+      expect(schema.fullname).to eq "person"
+    end
+
+    it "recursively finds schema definitions in subdirectories" do
+      FileUtils.mkdir_p("spec/schemas/foo/bar")
+
+      define_schema "foo/bar/person.avsc", <<-AVSC
+        {
+          "name": "foo.bar.person",
+          "type": "record",
+          "fields": [
+            {
+              "type": "string",
+              "name": "full_name"
+            }
+          ]
+        }
+      AVSC
+
+      # Warm the schema cache.
+      store.load_schemas!
+
+      # Force a failure if the schema file is read again.
+      FileUtils.rm("spec/schemas/foo/bar/person.avsc")
+
+      schema = store.find("foo.bar.person")
+      expect(schema.fullname).to eq "foo.bar.person"
+    end
+  end
 end


### PR DESCRIPTION
By calling `AvroTurf#load_schemas!` an application can eager load and cache all schemas defined in the schema directory.