### PR TITLE
WIP: Remove the overhead of data files

### DIFF
--- a/spec/avro_turf_spec.rb
+++ b/spec/avro_turf_spec.rb
@@ -30,20 +30,6 @@ describe AvroTurf do
 
       expect(avro.decode(encoded_data)).to eq(data)
     end
-
-    it "allows specifying a codec that should be used to compress messages" do
-      compressed_avro = AvroTurf.new(schemas_path: "spec/schemas/", codec: "deflate")
-
-      data = {
-        "full_name" => "John Doe" * 100
-      }
-
-      uncompressed_data = avro.encode(data, schema_name: "person")
-      compressed_data = compressed_avro.encode(data, schema_name: "person")
-
-      expect(compressed_data.bytesize).to be < uncompressed_data.bytesize
-      expect(compressed_avro.decode(compressed_data)).to eq(data)
-    end
   end
 
   describe "#decode" do


### PR DESCRIPTION
They're not needed when doing RPC style messaging. We don't want to force the Avro RPC mechanism on people, though.