### PR TITLE
Automatically coerce data when encoding

### DIFF
--- a/lib/avro_turf.rb
+++ b/lib/avro_turf.rb
@@ -2,6 +2,7 @@ require 'avro_turf/version'
 require 'avro'
 require 'json'
 require 'avro_turf/schema_store'
+require 'avro_turf/core_ext'
 
 class AvroTurf
   class Error < StandardError; end

--- a/lib/avro_turf.rb
+++ b/lib/avro_turf.rb
@@ -49,7 +49,7 @@ class AvroTurf
     writer = Avro::IO::DatumWriter.new(schema)
 
     dw = Avro::DataFile::Writer.new(stream, writer, schema, @codec)
-    dw << data
+    dw << data.as_avro
     dw.close
   end
 

--- a/lib/avro_turf/core_ext.rb
+++ b/lib/avro_turf/core_ext.rb
@@ -1,0 +1,7 @@
+require 'avro_turf/core_ext/string'
+require 'avro_turf/core_ext/numeric'
+require 'avro_turf/core_ext/enumerable'
+require 'avro_turf/core_ext/hash'
+require 'avro_turf/core_ext/time'
+require 'avro_turf/core_ext/date'
+require 'avro_turf/core_ext/symbol'

--- a/lib/avro_turf/core_ext/date.rb
+++ b/lib/avro_turf/core_ext/date.rb
@@ -1,0 +1,5 @@
+class Date
+  def as_avro
+    iso8601
+  end
+end

--- a/lib/avro_turf/core_ext/enumerable.rb
+++ b/lib/avro_turf/core_ext/enumerable.rb
@@ -1,0 +1,5 @@
+module Enumerable
+  def as_avro
+    map(&:as_avro)
+  end
+end

--- a/lib/avro_turf/core_ext/hash.rb
+++ b/lib/avro_turf/core_ext/hash.rb
@@ -1,0 +1,7 @@
+class Hash
+  def as_avro
+    hsh = Hash.new
+    each {|k, v| hsh[k.as_avro] = v.as_avro }
+    hsh
+  end
+end

--- a/lib/avro_turf/core_ext/numeric.rb
+++ b/lib/avro_turf/core_ext/numeric.rb
@@ -1,0 +1,5 @@
+class Numeric
+  def as_avro
+    self
+  end
+end

--- a/lib/avro_turf/core_ext/string.rb
+++ b/lib/avro_turf/core_ext/string.rb
@@ -1,0 +1,5 @@
+class String
+  def as_avro
+    self
+  end
+end

--- a/lib/avro_turf/core_ext/symbol.rb
+++ b/lib/avro_turf/core_ext/symbol.rb
@@ -1,0 +1,5 @@
+class Symbol
+  def as_avro
+    to_s
+  end
+end

--- a/lib/avro_turf/core_ext/time.rb
+++ b/lib/avro_turf/core_ext/time.rb
@@ -1,0 +1,5 @@
+class Time
+  def as_avro
+    iso8601
+  end
+end

--- a/spec/core_ext/date_spec.rb
+++ b/spec/core_ext/date_spec.rb
@@ -1,0 +1,6 @@
+describe Date, "#as_avro" do
+  it "returns an ISO8601 string describing the time" do
+    date = Date.today
+    expect(date.as_avro).to eq(date.iso8601)
+  end
+end

--- a/spec/core_ext/enumerable_spec.rb
+++ b/spec/core_ext/enumerable_spec.rb
@@ -1,0 +1,12 @@
+describe Enumerable, "#as_avro" do
+  it "returns an array" do
+    expect(Set.new.as_avro).to eq []
+  end
+
+  it "coerces the items to Avro" do
+    x = double(as_avro: "x")
+    y = double(as_avro: "y")
+
+    expect([x, y].as_avro).to eq ["x", "y"]
+  end
+end

--- a/spec/core_ext/hash_spec.rb
+++ b/spec/core_ext/hash_spec.rb
@@ -1,0 +1,8 @@
+describe Hash, "#as_avro" do
+  it "coerces the keys and values to Avro" do
+    x = double(as_avro: "x")
+    y = double(as_avro: "y")
+
+    expect({ x => y }.as_avro).to eq({ "x" => "y" })
+  end
+end

--- a/spec/core_ext/numeric_spec.rb
+++ b/spec/core_ext/numeric_spec.rb
@@ -1,0 +1,6 @@
+describe Numeric, "#as_avro" do
+  it "returns the number itself" do
+    expect(42.as_avro).to eq 42
+    expect(4.2.as_avro).to eq 4.2
+  end
+end

--- a/spec/core_ext/string_spec.rb
+++ b/spec/core_ext/string_spec.rb
@@ -1,0 +1,5 @@
+describe String, "#as_avro" do
+  it "returns itself" do
+    expect("hello".as_avro).to eq "hello"
+  end
+end

--- a/spec/core_ext/symbol_spec.rb
+++ b/spec/core_ext/symbol_spec.rb
@@ -1,0 +1,5 @@
+describe Symbol, "#as_avro" do
+  it "returns the String representation of the Symbol" do
+    expect(:hello.as_avro).to eq("hello")
+  end
+end

--- a/spec/core_ext/time_spec.rb
+++ b/spec/core_ext/time_spec.rb
@@ -1,0 +1,6 @@
+describe Time, "#as_avro" do
+  it "returns an ISO8601 string describing the time" do
+    time = Time.now
+    expect(time.as_avro).to eq(time.iso8601)
+  end
+end


### PR DESCRIPTION
This allows users to pass in e.g. Symbol, Time, Set, and other types that cannot be encoded natively in Avro.