### PR TITLE
Add basic support for schema-generated models

### DIFF
--- a/lib/avro_turf.rb
+++ b/lib/avro_turf.rb
@@ -92,8 +92,4 @@ class AvroTurf
   def load_schemas!
     @schema_store.load_schemas!
   end
-
-  def build_model(**options)
-    AvroTurf::Model.build(avro: self, **options)
-  end
 end

--- a/lib/avro_turf.rb
+++ b/lib/avro_turf.rb
@@ -94,6 +94,6 @@ class AvroTurf
   end
 
   def build_model(**options)
-    AvroTurf::Model.build(self, **options)
+    AvroTurf::Model.build(avro: self, **options)
   end
 end

--- a/lib/avro_turf.rb
+++ b/lib/avro_turf.rb
@@ -3,6 +3,7 @@ require 'avro'
 require 'json'
 require 'avro_turf/schema_store'
 require 'avro_turf/core_ext'
+require 'avro_turf/model'
 
 class AvroTurf
   class Error < StandardError; end
@@ -77,14 +78,22 @@ class AvroTurf
   #
   # Returns whatever is encoded in the stream.
   def decode_stream(stream, schema_name: nil, namespace: @namespace)
-    schema = schema_name && @schema_store.find(schema_name, namespace)
+    schema = schema_name && find_schema(schema_name, namespace)
     reader = Avro::IO::DatumReader.new(nil, schema)
     dr = Avro::DataFile::Reader.new(stream, reader)
     dr.first
   end
 
+  def find_schema(schema_name, namespace = nil)
+    @schema_store.find(schema_name, namespace)
+  end
+
   # Loads all schema definition files in the `schemas_dir`.
   def load_schemas!
     @schema_store.load_schemas!
+  end
+
+  def build_model(**options)
+    AvroTurf::Model.build(self, **options)
   end
 end

--- a/lib/avro_turf/model.rb
+++ b/lib/avro_turf/model.rb
@@ -4,7 +4,7 @@ class AvroTurf
     class << self
       attr_reader :schema, :avro
 
-      def build(avro: nil, schema_name: nil, schema: nil, **options)
+      def build(avro: nil, schema_name: nil, schema: nil, **options, &block)
         avro ||= AvroTurf.new(**options)
         schema ||= avro.find_schema(schema_name)
 
@@ -13,6 +13,8 @@ class AvroTurf
           @schema = schema
 
           define_methods_from_schema!
+
+          class_eval(&block) unless block.nil?
         end
       end
 

--- a/lib/avro_turf/model.rb
+++ b/lib/avro_turf/model.rb
@@ -1,39 +1,55 @@
 class AvroTurf
   class Model
-    def self.build(avro, schema_name: nil, schema: nil)
-      schema ||= avro.find_schema(schema_name)
 
-      Class.new(self) do
-        schema.fields.each do |field|
-          type = field.type
+    class << self
+      attr_reader :schema
 
-          attr_accessor field.name
+      def build(avro, schema_name: nil, schema: nil)
+        schema ||= avro.find_schema(schema_name)
 
-          case type.type_sym
-          when :enum
-            type.symbols.each do |symbol|
-              const_set(symbol.upcase, symbol)
-            end
-          when :record
-            klass = build(avro, schema: type)
+        Class.new(self) do
+          @avro = avro
+          @schema = schema
 
-            # hello_world -> HelloWorld
-            klass_name = type.name.
-              split("_").
-              map {|word| word[0] = word[0].upcase; word }.
-              join
+          schema.fields.each do |field|
+            type = field.type
 
-            const_set(klass_name, klass)
+            attr_accessor field.name
 
-            define_method("#{field.name}=") do |value|
-              instance_variable_set("@#{field.name}", klass.new(value))
+            case type.type_sym
+            when :enum
+              type.symbols.each do |symbol|
+                const_set(symbol.upcase, symbol)
+              end
+            when :record
+              klass = build(avro, schema: type)
+
+              # hello_world -> HelloWorld
+              klass_name = type.name.
+                split("_").
+                map {|word| word[0] = word[0].upcase; word }.
+                join
+
+              const_set(klass_name, klass)
+
+              define_method("#{field.name}=") do |value|
+                instance_variable_set("@#{field.name}", klass.new(value))
+              end
             end
           end
         end
       end
+
+      def encode(instance)
+        @avro.encode(instance, schema_name: @schema.name)
+      end
+
+      def decode(data)
+        new(@avro.decode(data, schema_name: @schema.name))
+      end
     end
 
-    def initialize(**attributes)
+    def initialize(attributes = nil)
       attributes.each do |attr, value|
         if respond_to?("#{attr}=")
           send("#{attr}=", value)
@@ -41,6 +57,22 @@ class AvroTurf
           raise ArgumentError, "no such attribute `#{attr}`"
         end
       end
+    end
+
+    def ==(other)
+      self.class.schema.fields.all? {|field|
+        self.send(field.name) == other.send(field.name)
+      }
+    end
+
+    def as_avro
+      self.class.schema.fields.each_with_object(Hash.new) do |field, hsh|
+        hsh[field.name] = send(field.name).as_avro
+      end
+    end
+
+    def encode
+      self.class.encode(self)
     end
   end
 end

--- a/lib/avro_turf/model.rb
+++ b/lib/avro_turf/model.rb
@@ -1,0 +1,46 @@
+class AvroTurf
+  class Model
+    def self.build(avro, schema_name: nil, schema: nil)
+      schema ||= avro.find_schema(schema_name)
+
+      Class.new(self) do
+        schema.fields.each do |field|
+          type = field.type
+
+          attr_accessor field.name
+
+          case type.type_sym
+          when :enum
+            type.symbols.each do |symbol|
+              const_set(symbol.upcase, symbol)
+            end
+          when :record
+            klass = build(avro, schema: type)
+
+            # hello_world -> HelloWorld
+            klass_name = type.name.
+              split("_").
+              map {|word| word[0] = word[0].upcase; word }.
+              join
+
+            const_set(klass_name, klass)
+
+            define_method("#{field.name}=") do |value|
+              instance_variable_set("@#{field.name}", klass.new(value))
+            end
+          end
+        end
+      end
+    end
+
+    def initialize(**attributes)
+      attributes.each do |attr, value|
+        if respond_to?("#{attr}=")
+          send("#{attr}=", value)
+        else
+          raise ArgumentError, "no such attribute `#{attr}`"
+        end
+      end
+    end
+  end
+end

--- a/lib/avro_turf/model.rb
+++ b/lib/avro_turf/model.rb
@@ -4,7 +4,8 @@ class AvroTurf
     class << self
       attr_reader :schema
 
-      def build(avro, schema_name: nil, schema: nil)
+      def build(avro: nil, schema_name: nil, schema: nil, **options)
+        avro ||= AvroTurf.new(**options)
         schema ||= avro.find_schema(schema_name)
 
         Class.new(self) do
@@ -22,7 +23,7 @@ class AvroTurf
                 const_set(symbol.upcase, symbol)
               end
             when :record
-              klass = build(avro, schema: type)
+              klass = build(avro: avro, schema: type)
 
               # hello_world -> HelloWorld
               klass_name = type.name.

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -151,4 +151,29 @@ describe AvroTurf::Model, ".build" do
 
     expect(klass.decode(person.encode)).to eq person
   end
+
+  it "allows adding custom methods to the class" do
+    define_schema "person.avsc", <<-AVSC
+      {
+        "name": "person",
+        "type": "record",
+        "fields": [
+          {
+            "name": "name",
+            "type": "string"
+          }
+        ]
+      }
+    AVSC
+
+    klass = AvroTurf::Model.build(avro: avro, schema_name: "person") do
+      def first_name
+        name.split(" ").first
+      end
+    end
+
+    person = klass.new(name: "Jane Doe")
+
+    expect(person.first_name).to eq "Jane"
+  end
 end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -118,4 +118,37 @@ describe AvroTurf::Model, ".build" do
     expect(list.value).to eq 1
     expect(list.next.value).to eq 2
   end
+
+  it "allows encoding a model instance" do
+    define_schema "person.avsc", <<-AVSC
+      {
+        "name": "person",
+        "type": "record",
+        "fields": [
+          {
+            "name": "address",
+            "type": {
+              "type": "record",
+              "name": "address",
+              "fields": [
+                {
+                  "name": "street",
+                  "type": "string"
+                },
+                {
+                  "name": "city",
+                  "type": "string"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    AVSC
+
+    klass = AvroTurf::Model.build(avro, schema_name: "person")
+    person = klass.new(address: { street: "Snaregade 12", city: "Copenhagen" })
+
+    expect(klass.decode(person.encode)).to eq person
+  end
 end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -1,0 +1,121 @@
+describe AvroTurf::Model, ".build" do
+  let(:avro) { AvroTurf.new(schemas_path: "spec/schemas/") }
+
+  before do
+    FileUtils.mkdir_p("spec/schemas")
+  end
+
+  it "adds accessors for each field in a record schema" do
+    define_schema "person.avsc", <<-AVSC
+      {
+        "name": "person",
+        "type": "record",
+        "fields": [
+          {
+            "name": "name",
+            "type": "string"
+          }
+        ]
+      }
+    AVSC
+
+    klass = AvroTurf::Model.build(avro, schema_name: "person")
+    person = klass.new(name: "Jane")
+
+    expect(person.name).to eq "Jane"
+
+    person.name = "Karen"
+
+    expect(person.name).to eq "Karen"
+  end
+
+  it "adds constants for enums" do
+    define_schema "card.avsc", <<-AVSC
+      {
+        "name": "card",
+        "type": "record",
+        "fields": [
+          {
+            "name": "suit",
+            "type": {
+              "type": "enum",
+              "name": "suit",
+              "symbols": ["hearts", "spades", "clubs", "diamonds"]
+            }
+          }
+        ]
+      }
+    AVSC
+
+    klass = AvroTurf::Model.build(avro, schema_name: "card")
+
+    expect(klass::DIAMONDS).to eq "diamonds"
+
+    card = klass.new(suit: "diamonds")
+
+    expect(card.suit).to eq "diamonds"
+  end
+
+  it "allows nested schemas" do
+    define_schema "person.avsc", <<-AVSC
+      {
+        "name": "person",
+        "type": "record",
+        "fields": [
+          {
+            "name": "address",
+            "type": {
+              "type": "record",
+              "name": "address",
+              "fields": [
+                {
+                  "name": "street",
+                  "type": "string"
+                },
+                {
+                  "name": "city",
+                  "type": "string"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    AVSC
+
+    klass = AvroTurf::Model.build(avro, schema_name: "person")
+
+    expect(klass::Address).not_to be_nil
+
+    person = klass.new(address: { street: "Snaregade 12", city: "Copenhagen" })
+
+    expect(person.address.street).to eq "Snaregade 12"
+    expect(person.address.city).to eq "Copenhagen"
+  end
+
+  it "handles recursive schemas" do
+    define_schema "cons.avsc", <<-AVSC
+      {
+        "name": "cons",
+        "type": "record",
+        "fields": [
+          {
+            "name": "value",
+            "type": "int"
+          },
+          {
+            "name": "next",
+            "type": ["cons", "null"]
+          }
+        ]
+      }
+    AVSC
+
+    klass = AvroTurf::Model.build(avro, schema_name: "cons")
+
+    list = klass.new(value: 1, next: klass.new(value: 2))
+
+    expect(list.value).to eq 1
+    expect(list.next.value).to eq 2
+  end
+end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -19,7 +19,7 @@ describe AvroTurf::Model, ".build" do
       }
     AVSC
 
-    klass = AvroTurf::Model.build(avro, schema_name: "person")
+    klass = AvroTurf::Model.build(avro: avro, schema_name: "person")
     person = klass.new(name: "Jane")
 
     expect(person.name).to eq "Jane"
@@ -47,7 +47,7 @@ describe AvroTurf::Model, ".build" do
       }
     AVSC
 
-    klass = AvroTurf::Model.build(avro, schema_name: "card")
+    klass = AvroTurf::Model.build(avro: avro, schema_name: "card")
 
     expect(klass::DIAMONDS).to eq "diamonds"
 
@@ -83,7 +83,7 @@ describe AvroTurf::Model, ".build" do
       }
     AVSC
 
-    klass = AvroTurf::Model.build(avro, schema_name: "person")
+    klass = AvroTurf::Model.build(avro: avro, schema_name: "person")
 
     expect(klass::Address).not_to be_nil
 
@@ -111,7 +111,7 @@ describe AvroTurf::Model, ".build" do
       }
     AVSC
 
-    klass = AvroTurf::Model.build(avro, schema_name: "cons")
+    klass = AvroTurf::Model.build(avro: avro, schema_name: "cons")
 
     list = klass.new(value: 1, next: klass.new(value: 2))
 
@@ -146,7 +146,7 @@ describe AvroTurf::Model, ".build" do
       }
     AVSC
 
-    klass = AvroTurf::Model.build(avro, schema_name: "person")
+    klass = AvroTurf::Model.build(avro: avro, schema_name: "person")
     person = klass.new(address: { street: "Snaregade 12", city: "Copenhagen" })
 
     expect(klass.decode(person.encode)).to eq person


### PR DESCRIPTION
The idea is to support code like this:

``` ruby
User = AvroTurf::Model.build(schema_name: "user") do
  # ...
end

user = User.new(name: "Joe", address: { street: "..." })

data = user.encode

User.decode(data) == user
```
