### PR TITLE
Allow validating data

### DIFF
--- a/lib/avro_turf.rb
+++ b/lib/avro_turf.rb
@@ -83,6 +83,20 @@ class AvroTurf
     dr.first
   end
 
+  # Validates data against an Avro schema.
+  #
+  # data        - The data that should be validated.
+  # schema    - The String name of the schema that should be used to validate
+  #             the data.
+  # namespace - The namespace of the Avro schema (optional).
+  #
+  # Returns true if the data is valid, false otherwise.
+  def valid?(data, schema_name: nil, namespace: @namespace)
+    schema = schema_name && @schema_store.find(schema_name, namespace)
+
+    Avro::Schema.validate(schema, data)
+  end
+
   # Loads all schema definition files in the `schemas_dir`.
   def load_schemas!
     @schema_store.load_schemas!

--- a/spec/avro_turf_spec.rb
+++ b/spec/avro_turf_spec.rb
@@ -122,4 +122,25 @@ describe AvroTurf do
       expect(avro.decode_stream(stream)).to eq "hello"
     end
   end
+
+  describe "#valid?" do
+    before do
+      define_schema "message.avsc", <<-AVSC
+        {
+          "name": "message",
+          "type": "string"
+        }
+      AVSC
+    end
+
+    it "returns true if the datum matches the schema" do
+      datum = "hello"
+      expect(avro.valid?(datum, schema_name: "message")).to eq true
+    end
+
+    it "returns false if the datum does not match the schema" do
+      datum = 42
+      expect(avro.valid?(datum, schema_name: "message")).to eq false
+    end
+  end
 end


### PR DESCRIPTION
Sometimes you just want to use Avro to validate data rather than encode it. This change exposes the validation API with the magic Avro Turf sprinkles on top.