### PR TITLE
Update gemspec to allow Avro 1.8.0

### DIFF
--- a/avro_turf.gemspec
+++ b/avro_turf.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "avro", "~> 1.7.7"
+  spec.add_dependency "avro", ">= 1.7.7", "< 1.9"
   spec.add_dependency "excon", "~> 0.45.4"
 
   spec.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
Tests pass with the current, released v1.8.0 version of the avro gem.

I've updated the restriction conservatively to only allow 1.7.7-1.8.x.