### PR TITLE
Expand Schema Registry support

### DIFF
--- a/avro_turf.gemspec
+++ b/avro_turf.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "fakefs", "~> 0.6.7"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "sinatra"
+  spec.add_development_dependency "json_spec"
 end

--- a/lib/avro_turf/cached_schema_registry.rb
+++ b/lib/avro_turf/cached_schema_registry.rb
@@ -1,12 +1,19 @@
 require 'avro_turf/schema_registry'
 
 # Caches registrations and lookups to the schema registry in memory.
-class AvroTurf::CachedSchemaRegistry < DelegateClass(AvroTurf::SchemaRegistry)
+class AvroTurf::CachedSchemaRegistry
 
   def initialize(upstream)
-    @upstream = super(upstream)
+    @upstream = upstream
     @schemas_by_id = {}
     @ids_by_schema = {}
+  end
+
+  # Delegate the following methods to the upstream
+  %i(subjects subject_versions subject_version check).each do |name|
+    define_method(name) do |*args|
+      instance_variable_get(:@upstream).send(name, *args)
+    end
   end
 
   def fetch(id)

--- a/lib/avro_turf/cached_schema_registry.rb
+++ b/lib/avro_turf/cached_schema_registry.rb
@@ -1,7 +1,10 @@
+require 'avro_turf/schema_registry'
+
 # Caches registrations and lookups to the schema registry in memory.
-class AvroTurf::CachedSchemaRegistry
+class AvroTurf::CachedSchemaRegistry < DelegateClass(AvroTurf::SchemaRegistry)
+
   def initialize(upstream)
-    @upstream = upstream
+    @upstream = super(upstream)
     @schemas_by_id = {}
     @ids_by_schema = {}
   end

--- a/lib/avro_turf/schema_registry.rb
+++ b/lib/avro_turf/schema_registry.rb
@@ -28,6 +28,29 @@ class AvroTurf::SchemaRegistry
     id
   end
 
+  # List all subjects
+  def subjects
+    get('/subjects')
+  end
+
+  # List all versions for a subject
+  def subject_versions(subject)
+    get("/subjects/#{subject}/versions")
+  end
+
+  # Get a specific version for a subject
+  def subject_version(subject, version = 'latest')
+    get("/subjects/#{subject}/versions/#{version}")
+  end
+
+  # Check if a schema exists. Returns nil if not found.
+  def check(subject, schema)
+    data = post("/subjects/#{subject}",
+                expects: [200, 404],
+                body: { schema: schema }.to_json)
+    data unless data.has_key?("error_code")
+  end
+
   private
 
   def get(path, **options)

--- a/lib/avro_turf/schema_registry.rb
+++ b/lib/avro_turf/schema_registry.rb
@@ -62,7 +62,8 @@ class AvroTurf::SchemaRegistry
   end
 
   def request(path, **options)
-    response = @connection.request(path: path, expects: 200, **options)
+    options = { expects: 200 }.merge!(options)
+    response = @connection.request(path: path, **options)
     JSON.parse(response.body)
   end
 end

--- a/spec/cached_schema_registry_spec.rb
+++ b/spec/cached_schema_registry_spec.rb
@@ -1,0 +1,41 @@
+require 'webmock/rspec'
+require 'avro_turf/cached_schema_registry'
+require_relative 'fake_schema_registry_server'
+
+describe AvroTurf::CachedSchemaRegistry do
+  let(:upstream) { instance_double(AvroTurf::SchemaRegistry) }
+  let(:registry) { described_class.new(upstream) }
+  let(:id) { rand(999) }
+  let(:schema) do
+    {
+      type: "record",
+      name: "person",
+      fields: [{ name: "name", type: "string" }]
+    }.to_json
+  end
+
+  describe "#fetch" do
+    it "caches the result of fetch" do
+      allow(upstream).to receive(:fetch).with(id).and_return(schema)
+      registry.fetch(id)
+      expect(registry.fetch(id)).to eq(schema)
+      expect(upstream).to have_received(:fetch).exactly(1).times
+    end
+  end
+
+  describe "#register" do
+    let(:subject_name) { "a_subject" }
+
+    it "caches the result of register" do
+      allow(upstream).to receive(:register).with(subject_name, schema).and_return(id)
+      registry.register(subject_name, schema)
+      expect(registry.register(subject_name, schema)).to eq(id)
+      expect(upstream).to have_received(:register).exactly(1).times
+    end
+  end
+
+  it_behaves_like "a schema registry client" do
+    let(:upstream) { AvroTurf::SchemaRegistry.new(registry_url, logger: logger) }
+    let(:registry) { described_class.new(upstream) }
+  end
+end

--- a/spec/fake_schema_registry_server.rb
+++ b/spec/fake_schema_registry_server.rb
@@ -3,19 +3,22 @@ require 'sinatra/base'
 class FakeSchemaRegistryServer < Sinatra::Base
   SUBJECTS = Hash.new { Array.new }
   SCHEMAS = []
+  SUBJECT_NOT_FOUND = { error_code: 40401, message: 'Subject not found' }.to_json.freeze
+  VERSION_NOT_FOUND = { error_code: 40402, message: 'Version not found' }.to_json.freeze
+  SCHEMA_NOT_FOUND = { error_code: 40403, message: 'Schema not found' }.to_json.freeze
 
   helpers do
-    def validate_schema(schema)
-      Avro::Schema.parse(schema)
+    def parse_schema
+      request.body.rewind
+      JSON.parse(request.body.read).fetch("schema").tap do |schema|
+        Avro::Schema.parse(schema)
+      end
     end
   end
 
   post "/subjects/:subject/versions" do
-    request.body.rewind
-    schema = JSON.parse(request.body.read).fetch("schema")
+    SCHEMAS << parse_schema
 
-    validate_schema(schema)
-    SCHEMAS << schema
     schema_id = SCHEMAS.size - 1
     SUBJECTS[params[:subject]] = SUBJECTS[params[:subject]] << schema_id
     { id: schema_id }.to_json
@@ -23,7 +26,7 @@ class FakeSchemaRegistryServer < Sinatra::Base
 
   get "/schemas/ids/:schema_id" do
     schema = SCHEMAS.at(params[:schema_id].to_i)
-
+    halt(404, SCHEMA_NOT_FOUND) unless schema
     { schema: schema }.to_json
   end
 
@@ -33,17 +36,20 @@ class FakeSchemaRegistryServer < Sinatra::Base
 
   get "/subjects/:subject/versions" do
     schema_ids = SUBJECTS[params[:subject]]
+    halt(404, SUBJECT_NOT_FOUND) if schema_ids.empty?
     (1..schema_ids.size).to_a.to_json
   end
 
   get "/subjects/:subject/versions/:version" do
     schema_ids = SUBJECTS[params[:subject]]
+    halt(404, SUBJECT_NOT_FOUND) if schema_ids.empty?
 
     schema_id = if params[:version] == 'latest'
                   schema_ids.last
                 else
                   schema_ids.at(Integer(params[:version]) - 1)
                 end
+    halt(404, VERSION_NOT_FOUND) unless schema_id
 
     schema = SCHEMAS.at(schema_id)
 
@@ -55,26 +61,20 @@ class FakeSchemaRegistryServer < Sinatra::Base
   end
 
   post "/subjects/:subject" do
-    request.body.rewind
-    schema = JSON.parse(request.body.read).fetch("schema")
+    schema = parse_schema
 
     # Note: this does not actually handle the same schema registered under
     # multiple subjects
     schema_id = SCHEMAS.index(schema)
 
-    if schema_id
-      {
-        subject: params[:subject],
-        id: schema_id,
-        version: SUBJECTS[params[:subject]].index(schema_id) + 1,
-        schema: schema
-      }
-    else
-      {
-        error_code: 40403,
-        message: 'Schema not found'
-      }
-    end.to_json
+    halt(404, SCHEMA_NOT_FOUND) unless schema_id
+
+    {
+      subject: params[:subject],
+      id: schema_id,
+      version: SUBJECTS[params[:subject]].index(schema_id) + 1,
+      schema: schema
+    }.to_json
   end
 
   def self.clear

--- a/spec/fake_schema_registry_server.rb
+++ b/spec/fake_schema_registry_server.rb
@@ -1,6 +1,7 @@
 require 'sinatra/base'
 
 class FakeSchemaRegistryServer < Sinatra::Base
+  SUBJECTS = Hash.new { Array.new }
   SCHEMAS = []
 
   helpers do
@@ -16,7 +17,7 @@ class FakeSchemaRegistryServer < Sinatra::Base
     validate_schema(schema)
     SCHEMAS << schema
     schema_id = SCHEMAS.size - 1
-
+    SUBJECTS[params[:subject]] = SUBJECTS[params[:subject]] << schema_id
     { id: schema_id }.to_json
   end
 
@@ -26,7 +27,58 @@ class FakeSchemaRegistryServer < Sinatra::Base
     { schema: schema }.to_json
   end
 
+  get "/subjects" do
+    SUBJECTS.keys.to_json
+  end
+
+  get "/subjects/:subject/versions" do
+    schema_ids = SUBJECTS[params[:subject]]
+    (1..schema_ids.size).to_a.to_json
+  end
+
+  get "/subjects/:subject/versions/:version" do
+    schema_ids = SUBJECTS[params[:subject]]
+
+    schema_id = if params[:version] == 'latest'
+                  schema_ids.last
+                else
+                  schema_ids.at(Integer(params[:version]) - 1)
+                end
+
+    schema = SCHEMAS.at(schema_id)
+
+    {
+      name: params[:subject],
+      version: schema_ids.index(schema_id) + 1,
+      schema: schema
+    }.to_json
+  end
+
+  post "/subjects/:subject" do
+    request.body.rewind
+    schema = JSON.parse(request.body.read).fetch("schema")
+
+    # Note: this does not actually handle the same schema registered under
+    # multiple subjects
+    schema_id = SCHEMAS.index(schema)
+
+    if schema_id
+      {
+        subject: params[:subject],
+        id: schema_id,
+        version: SUBJECTS[params[:subject]].index(schema_id) + 1,
+        schema: schema
+      }
+    else
+      {
+        error_code: 40403,
+        message: 'Schema not found'
+      }
+    end.to_json
+  end
+
   def self.clear
+    SUBJECTS.clear
     SCHEMAS.clear
   end
 end

--- a/spec/schema_registry_spec.rb
+++ b/spec/schema_registry_spec.rb
@@ -3,30 +3,7 @@ require 'avro_turf/schema_registry'
 require_relative 'fake_schema_registry_server'
 
 describe AvroTurf::SchemaRegistry do
-  let(:registry_url) { "http://registry.example.com" }
-
-  before do
-    stub_request(:any, /^#{registry_url}/).to_rack(FakeSchemaRegistryServer)
-    FakeSchemaRegistryServer.clear
-  end
-
-  it "allows registering a schema" do
-    logger = Logger.new(StringIO.new)
-    registry = described_class.new(registry_url, logger: logger)
-
-    schema = <<-JSON
-      {
-        "type": "record",
-        "name": "person",
-        "fields": [
-          { "name": "name", "type": "string" }
-        ]
-      }
-    JSON
-
-    id = registry.register("some-subject", schema)
-    fetched_schema = registry.fetch(id)
-
-    expect(JSON.parse(fetched_schema)).to eq JSON.parse(schema)
+  it_behaves_like "a schema registry client" do
+    let(:registry) { described_class.new(registry_url, logger: logger) }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,10 @@
 require 'bundler/setup'
 require 'logger'
+require 'json_spec'
 require 'fakefs/spec_helpers'
 require 'avro_turf'
+
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 module Helpers
   def define_schema(path, content)

--- a/spec/support/schema_registry_context.rb
+++ b/spec/support/schema_registry_context.rb
@@ -28,6 +28,16 @@ shared_examples_for "a schema registry client" do
     end
   end
 
+  describe "#fetch" do
+    context "when the schema does not exist" do
+      it "raises an error" do
+        expect do
+          registry.fetch(-1)
+        end.to raise_error(Excon::Errors::NotFound)
+      end
+    end
+  end
+
   describe "#subjects" do
     it "lists the subjects in the registry" do
       subjects = Array.new(2) { |n| "subject#{n}" }
@@ -44,6 +54,16 @@ shared_examples_for "a schema registry client" do
       end
       expect(registry.subject_versions(subject_name))
         .to be_json_eql((1..2).to_a.to_json)
+    end
+
+    context "when the subject does not exist" do
+      let(:subject_name) { 'missing' }
+
+      it "raises an error" do
+        expect do
+          registry.subject_versions(subject_name).inspect
+        end.to raise_error(Excon::Errors::NotFound)
+      end
     end
   end
 
@@ -79,6 +99,22 @@ shared_examples_for "a schema registry client" do
       it "returns the latest version" do
         expect(registry.subject_version(subject_name))
           .to eq(JSON.parse(expected))
+      end
+    end
+
+    context "when the subject does not exist" do
+      it "raises an error" do
+        expect do
+          registry.subject_version('missing')
+        end.to raise_error(Excon::Errors::NotFound)
+      end
+    end
+
+    context "when the version does not exist" do
+      it "raises an error" do
+        expect do
+          registry.subject_version(subject_name, 3)
+        end.to raise_error(Excon::Errors::NotFound)
       end
     end
   end

--- a/spec/support/schema_registry_context.rb
+++ b/spec/support/schema_registry_context.rb
@@ -1,0 +1,108 @@
+# This shared example expects a registry variable to be defined
+# with an instance of the registry class being tested.
+shared_examples_for "a schema registry client" do
+  let(:logger) { Logger.new(StringIO.new) }
+  let(:registry_url) { "http://registry.example.com" }
+  let(:subject_name) { "some-subject" }
+  let(:schema) do
+    {
+      type: "record",
+      name: "person",
+      fields: [
+        { name: "name", type: "string" }
+      ]
+    }.to_json
+  end
+
+  before do
+    stub_request(:any, /^#{registry_url}/).to_rack(FakeSchemaRegistryServer)
+    FakeSchemaRegistryServer.clear
+  end
+
+  describe "#register and #fetch" do
+    it "allows registering a schema" do
+      id = registry.register(subject_name, schema)
+      fetched_schema = registry.fetch(id)
+
+      expect(fetched_schema).to eq(schema)
+    end
+  end
+
+  describe "#subjects" do
+    it "lists the subjects in the registry" do
+      subjects = Array.new(2) { |n| "subject#{n}" }
+      subjects.each { |subject| registry.register(subject, schema) }
+      expect(registry.subjects).to be_json_eql(subjects.to_json)
+    end
+  end
+
+  describe "#subject_versions" do
+    it "lists all the versions for the subject" do
+      2.times do |n|
+        registry.register(subject_name,
+                          { type: :record, name: "r#{n}", fields: [] }.to_json)
+      end
+      expect(registry.subject_versions(subject_name))
+        .to be_json_eql((1..2).to_a.to_json)
+    end
+  end
+
+  describe "#subject_version" do
+    before do
+      2.times do |n|
+        registry.register(subject_name,
+                          { type: :record, name: "r#{n}", fields: [] }.to_json)
+      end
+    end
+    let(:expected) do
+      {
+        name: subject_name,
+        version: 1,
+        schema: { type: :record, name: "r0", fields: [] }.to_json
+      }.to_json
+    end
+
+    it "returns a specific version of a schema" do
+      expect(registry.subject_version(subject_name, 1))
+        .to eq(JSON.parse(expected))
+    end
+
+    context "when the version is not specified" do
+      let(:expected) do
+        {
+          name: subject_name,
+          version: 2,
+          schema: { type: :record, name: "r1", fields: [] }.to_json
+        }.to_json
+      end
+
+      it "returns the latest version" do
+        expect(registry.subject_version(subject_name))
+          .to eq(JSON.parse(expected))
+      end
+    end
+  end
+
+  describe "#check" do
+    context "when the schema exists" do
+      let!(:schema_id) { registry.register(subject_name, schema) }
+      let(:expected) do
+        {
+          subject: subject_name,
+          id: schema_id,
+          version: 1,
+          schema: schema
+        }.to_json
+      end
+      it "returns the schema details" do
+        expect(registry.check(subject_name, schema)).to eq(JSON.parse(expected))
+      end
+    end
+
+    context "when the schema is not registered" do
+      it "returns nil" do
+        expect(registry.check("missing", schema)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change completes support for the Subjects resource of the Schema Registry. Responses for the additional endpoints are not cached. The `CachedSchemaRegistry` is modified to delegate to the upstream `SchemaRegistry` so that the same API is available via either registry.

The `FakeSchemaRegistry` had to also be expanded to support testing. Tests have been refactored into a shared example that is used to test both the cached and the regular `SchemaRegistry`.