### PR TITLE
Call Avro::Schema#to_s in the Messaging API

### DIFF
--- a/avro_turf.gemspec
+++ b/avro_turf.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "fakefs", "~> 0.6.7"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "sinatra"
+  spec.add_development_dependency "activesupport"
 end

--- a/avro_turf.gemspec
+++ b/avro_turf.gemspec
@@ -26,5 +26,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "fakefs", "~> 0.6.7"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "sinatra"
-  spec.add_development_dependency "activesupport"
 end

--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -44,7 +44,7 @@ class AvroTurf
 
       # Schemas are registered under the full name of the top level Avro record
       # type.
-      schema_id = @registry.register(schema.fullname, schema)
+      schema_id = @registry.register(schema.fullname, schema.to_s)
 
       stream = StringIO.new
       writer = Avro::IO::DatumWriter.new(schema)

--- a/spec/fake_schema_registry_server.rb
+++ b/spec/fake_schema_registry_server.rb
@@ -3,10 +3,17 @@ require 'sinatra/base'
 class FakeSchemaRegistryServer < Sinatra::Base
   SCHEMAS = []
 
+  helpers do
+    def validate_schema(schema)
+      Avro::Schema.parse(schema)
+    end
+  end
+
   post "/subjects/:subject/versions" do
     request.body.rewind
     schema = JSON.parse(request.body.read).fetch("schema")
 
+    validate_schema(schema)
     SCHEMAS << schema
     schema_id = SCHEMAS.size - 1
 

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -2,6 +2,11 @@ require 'webmock/rspec'
 require 'avro_turf/messaging'
 require_relative 'fake_schema_registry_server'
 
+# active_support/core_ext is required only to defensively test
+# against how it interferes with JSON encoding
+require 'active_support'
+require 'active_support/core_ext'
+
 describe AvroTurf::Messaging do
   let(:registry_url) { "http://registry.example.com" }
   let(:logger) { Logger.new(StringIO.new) }

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -56,18 +56,16 @@ describe AvroTurf::Messaging do
         # Simulate the presence of active_support/core_ext by monkey patching
         # the schema store to monkey patch #to_json on the returned schema.
         schema_store = messaging.instance_variable_get(:@schema_store)
-        class << schema_store
-          def find(*_args)
-            super.extend(Module.new do
-              # Replace to_json on the returned schema with an implementation
-              # that returns something similar to active_support/core_ext/json
-              def to_json(*args)
-                instance_variables.each_with_object(Hash.new) do |ivar, result|
-                  result[ivar.to_s.sub('@','')] = instance_variable_get(ivar)
-                end.to_json(*args)
-              end
-            end)
-          end
+        def schema_store.find(*)
+          super.extend(Module.new do
+            # Replace to_json on the returned schema with an implementation
+            # that returns something similar to active_support/core_ext/json
+            def to_json(*args)
+              instance_variables.each_with_object(Hash.new) do |ivar, result|
+                result[ivar.to_s.sub('@','')] = instance_variable_get(ivar)
+              end.to_json(*args)
+            end
+          end)
         end
       end
     end

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -2,11 +2,6 @@ require 'webmock/rspec'
 require 'avro_turf/messaging'
 require_relative 'fake_schema_registry_server'
 
-# active_support/core_ext is required only to defensively test
-# against how it interferes with JSON encoding
-require 'active_support'
-require 'active_support/core_ext'
-
 describe AvroTurf::Messaging do
   let(:registry_url) { "http://registry.example.com" }
   let(:logger) { Logger.new(StringIO.new) }
@@ -53,5 +48,34 @@ describe AvroTurf::Messaging do
     message = { "full_name" => "John Doe" }
     data = avro.encode(message, schema_name: "person")
     expect(avro.decode(data, schema_name: "person")).to eq message
+  end
+
+  context "when active_support/core_ext is present" do
+    let(:avro) do
+      super().tap do |messaging|
+        # Simulate the presence of active_support/core_ext by monkey patching
+        # the schema store to monkey patch #to_json on the returned schema.
+        schema_store = messaging.instance_variable_get(:@schema_store)
+        class << schema_store
+          def find(*_args)
+            super.extend(Module.new do
+              # Replace to_json on the returned schema with an implementation
+              # that returns something similar to active_support/core_ext/json
+              def to_json(*args)
+                instance_variables.each_with_object(Hash.new) do |ivar, result|
+                  result[ivar.to_s.sub('@','')] = instance_variable_get(ivar)
+                end.to_json(*args)
+              end
+            end)
+          end
+        end
+      end
+    end
+
+    it "encodes and decodes messages" do
+      message = { "full_name" => "John Doe" }
+      data = avro.encode(message, schema_name: "person")
+      expect(avro.decode(data)).to eq message
+    end
   end
 end


### PR DESCRIPTION
This fixes a bug that I ran into using this gem in a Rails application.

ActiveSupport interferes with how an Avro::Schema is converted to JSON. By calling `#to_s` on the Avro::Schema in the call to `SchemaRegistry#register` we ensure that the schema is converted to the Avro JSON schema.

`activesupport` is added as a dev dependency here to provoke the problem.