### PR TITLE
Handle leading slash on schema_path

### DIFF
--- a/lib/avro_turf/schema_store.rb
+++ b/lib/avro_turf/schema_store.rb
@@ -46,7 +46,7 @@ class AvroTurf::SchemaStore
 
     Dir.glob(pattern) do |schema_path|
       # Remove the path prefix.
-      schema_path.sub!(/^\/#{@path}\//, "")
+      schema_path.sub!(/^\/?#{@path}\//, "")
 
       # Replace `/` with `.` and chop off the file extension.
       schema_name = File.basename(schema_path.tr("/", "."), ".avsc")


### PR DESCRIPTION
Without this change, `load_schemas!` fails to strip the path prefix when using an absolute `schema_path`.