### PR TITLE
Allow schema store to be specified for AvroTurf::Messaging

### DIFF
--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -20,13 +20,14 @@ class AvroTurf
     # Instantiate a new Messaging instance with the given configuration.
     #
     # registry_url - The String URL of the schema registry that should be used.
+    # schema_store - A schema store object that responds to #find(schema_name, namespace).
     # schemas_path - The String file system path where local schemas are stored.
     # namespace    - The String default schema namespace.
     # logger       - The Logger that should be used to log information (optional).
-    def initialize(registry_url: nil, schemas_path: nil, namespace: nil, logger: nil)
+    def initialize(registry_url: nil, schema_store: nil, schemas_path: nil, namespace: nil, logger: nil)
       @logger = logger || Logger.new($stderr)
       @namespace = namespace
-      @schema_store = SchemaStore.new(path: schemas_path || DEFAULT_SCHEMAS_PATH)
+      @schema_store = schema_store || SchemaStore.new(path: schemas_path || DEFAULT_SCHEMAS_PATH)
       @registry = CachedSchemaRegistry.new(SchemaRegistry.new(registry_url, logger: @logger))
       @schemas_by_id = {}
     end

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -40,47 +40,45 @@ describe AvroTurf::Messaging do
     AVSC
   end
 
-  it "encodes and decodes messages" do
-    data = avro.encode(message, schema_name: "person")
-    expect(avro.decode(data)).to eq message
-  end
-
-  it "allows specifying a reader's schema" do
-    data = avro.encode(message, schema_name: "person")
-    expect(avro.decode(data, schema_name: "person")).to eq message
-  end
-
-  it "caches parsed schemas for decoding" do
-    data = avro.encode(message, schema_name: "person")
-    avro.decode(data)
-    allow(Avro::Schema).to receive(:parse).and_call_original
-    expect(avro.decode(data)).to eq message
-    expect(Avro::Schema).not_to have_received(:parse)
-  end
-
-  context "when active_support/core_ext is present" do
-    let(:avro) do
-      super().tap do |messaging|
-        # Simulate the presence of active_support/core_ext by monkey patching
-        # the schema store to monkey patch #to_json on the returned schema.
-        schema_store = messaging.instance_variable_get(:@schema_store)
-        def schema_store.find(*)
-          super.extend(Module.new do
-            # Replace to_json on the returned schema with an implementation
-            # that returns something similar to active_support/core_ext/json
-            def to_json(*args)
-              instance_variables.each_with_object(Hash.new) do |ivar, result|
-                result[ivar.to_s.sub('@','')] = instance_variable_get(ivar)
-              end.to_json(*args)
-            end
-          end)
-        end
-      end
-    end
-
+  shared_examples_for "encoding and decoding" do
     it "encodes and decodes messages" do
       data = avro.encode(message, schema_name: "person")
       expect(avro.decode(data)).to eq message
+    end
+
+    it "allows specifying a reader's schema" do
+      data = avro.encode(message, schema_name: "person")
+      expect(avro.decode(data, schema_name: "person")).to eq message
+    end
+
+    it "caches parsed schemas for decoding" do
+      data = avro.encode(message, schema_name: "person")
+      avro.decode(data)
+      allow(Avro::Schema).to receive(:parse).and_call_original
+      expect(avro.decode(data)).to eq message
+      expect(Avro::Schema).not_to have_received(:parse)
+    end
+  end
+
+  it_behaves_like "encoding and decoding"
+
+  context "with a provided schema store" do
+    let(:schema_store) { AvroTurf::SchemaStore.new(path: "spec/schemas") }
+
+    let(:avro) do
+      AvroTurf::Messaging.new(
+        registry_url: registry_url,
+        schema_store: schema_store,
+        logger: logger
+      )
+    end
+
+    it_behaves_like "encoding and decoding"
+
+    it "uses the provided schema store" do
+      allow(schema_store).to receive(:find).and_call_original
+      avro.encode(message, schema_name: "person")
+      expect(schema_store).to have_received(:find).with("person", nil)
     end
   end
 end


### PR DESCRIPTION
This change allows the schema store to be specified when creating a `Messaging` instance.

The motivation is to allow a different implementation of the schema store interface to be plugged into the `Messaging` API.