### PR TITLE
Allow schema registry to be injected into AvroTurf::Messaging

### DIFF
--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -19,16 +19,18 @@ class AvroTurf
 
     # Instantiate a new Messaging instance with the given configuration.
     #
+    # registry     - A schema registry object that responds to all methods in the
+    #                AvroTurf::SchemaRegistry interface.
     # registry_url - The String URL of the schema registry that should be used.
     # schema_store - A schema store object that responds to #find(schema_name, namespace).
     # schemas_path - The String file system path where local schemas are stored.
     # namespace    - The String default schema namespace.
     # logger       - The Logger that should be used to log information (optional).
-    def initialize(registry_url: nil, schema_store: nil, schemas_path: nil, namespace: nil, logger: nil)
+    def initialize(registry: nil, registry_url: nil, schema_store: nil, schemas_path: nil, namespace: nil, logger: nil)
       @logger = logger || Logger.new($stderr)
       @namespace = namespace
       @schema_store = schema_store || SchemaStore.new(path: schemas_path || DEFAULT_SCHEMAS_PATH)
-      @registry = CachedSchemaRegistry.new(SchemaRegistry.new(registry_url, logger: @logger))
+      @registry = registry || CachedSchemaRegistry.new(SchemaRegistry.new(registry_url, logger: @logger))
       @schemas_by_id = {}
     end
 

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -62,6 +62,27 @@ describe AvroTurf::Messaging do
 
   it_behaves_like "encoding and decoding"
 
+  context "with a provided registry" do
+    let(:registry) { AvroTurf::SchemaRegistry.new(registry_url, logger: logger) }
+
+    let(:avro) do
+      AvroTurf::Messaging.new(
+        registry: registry,
+        schemas_path: "spec/schemas",
+        logger: logger
+      )
+    end
+
+    it_behaves_like "encoding and decoding"
+
+    it "uses the provided registry" do
+      allow(registry).to receive(:register).and_call_original
+      message = { "full_name" => "John Doe" }
+      avro.encode(message, schema_name: "person")
+      expect(registry).to have_received(:register)
+    end
+  end
+
   context "with a provided schema store" do
     let(:schema_store) { AvroTurf::SchemaStore.new(path: "spec/schemas") }
 


### PR DESCRIPTION
This change allows the schema registry to be specified when creating a `Messaging` instance.

The motivation is to allow a different implementation of the schema registry interface to be plugged into the Messaging API (e.g. for authentication, caching across threads, etc).