### PR TITLE
Monkey-patch to properly handle falsey default values in Avro

### DIFF
--- a/lib/avro_turf.rb
+++ b/lib/avro_turf.rb
@@ -3,6 +3,7 @@ require 'avro'
 require 'json'
 require 'avro_turf/schema_store'
 require 'avro_turf/core_ext'
+require 'avro_turf/schema_to_avro_patch'
 
 class AvroTurf
   class Error < StandardError; end

--- a/lib/avro_turf/schema_to_avro_patch.rb
+++ b/lib/avro_turf/schema_to_avro_patch.rb
@@ -1,0 +1,41 @@
+class AvroTurf
+  module AvroGemPatch
+    module RecordSchema
+      module ClassMethods
+        def make_field_objects(field_data, names, namespace=nil)
+          new_field_data = []
+          field_data.each do |field|
+            if field.respond_to?(:[]) && !field.key?('default')
+              field = field.clone
+              field['default'] = :no_default
+            end
+            new_field_data << field
+          end
+          super(new_field_data, names, namespace)
+        end
+      end
+      
+      def self.prepended(base)
+        class << base
+          prepend ClassMethods
+        end
+      end
+    end
+    
+    module Field
+      def initialize(type, name, default=:no_default, order=nil, names=nil, namespace=nil)
+        super(type, name, default, order, names, namespace)
+      end
+      
+      def to_avro(names=Set.new)
+        {'name' => name, 'type' => type.to_avro(names)}.tap do |avro|
+          avro['default'] = default unless default == :no_default
+          avro['order'] = order if order
+        end
+      end
+    end
+  end
+end
+
+Avro::Schema::RecordSchema.send(:prepend, AvroTurf::AvroGemPatch::RecordSchema)
+Avro::Schema::Field.send(:prepend, AvroTurf::AvroGemPatch::Field)

--- a/spec/schema_to_avro_patch_spec.rb
+++ b/spec/schema_to_avro_patch_spec.rb
@@ -1,0 +1,24 @@
+require 'webmock/rspec'
+
+# This spec verifies the monkey-patch that we have to apply until the avro
+# gem releases a fix for bug AVRO-1848:
+# https://issues.apache.org/jira/browse/AVRO-1848
+
+describe Avro::Schema do
+  it "correctly handles falsey field defaults" do
+    schema = Avro::Schema.parse <<-SCHEMA
+      {"type": "record", "name": "Record", "namespace": "my.name.space",
+        "fields": [
+          {"name": "is_usable", "type": "boolean", "default": false}
+        ]
+      }
+    SCHEMA
+    
+    expect(schema.to_avro).to eq({
+      'type' => 'record', 'name' => 'Record', 'namespace' => 'my.name.space',
+      'fields' => [
+        {'name' => 'is_usable', 'type' => 'boolean', 'default' => false}
+      ]
+    })
+  end
+end


### PR DESCRIPTION
Necessary to work around buggy behavior in the `avro` gem until [this bug is fixed.](https://issues.apache.org/jira/browse/AVRO-1848)