### PR TITLE
Relax excon version restriction

### DIFF
--- a/avro_turf.gemspec
+++ b/avro_turf.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "avro", ">= 1.7.7", "< 1.9"
-  spec.add_dependency "excon", "~> 0.45.4"
+  spec.add_dependency "excon", ">= 0.45.4"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Is there a reason for the tight version restriction on excon?

This PR is just one suggestion for relaxing it if there are no known issues with later versions.