### PR TITLE
Relax excon constraint

### DIFF
--- a/avro_turf.gemspec
+++ b/avro_turf.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "avro", ">= 1.7.7", "< 1.9"
-  spec.add_dependency "excon", "~> 0.45.4"
+  spec.add_dependency "excon", "~> 0.45"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
This relaxes the `excon` constraint in the gemspec. I tested with version `0.48.0` and all specs are passing.