### PR TITLE
Allow setting the schema registry subject when encoding

### DIFF
--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -43,12 +43,12 @@ class AvroTurf
     # namespace   - The namespace of the schema (optional).
     #
     # Returns the encoded data as a String.
-    def encode(message, schema_name: nil, namespace: @namespace)
+    def encode(message, schema_name: nil, namespace: @namespace, subject: nil)
       schema = @schema_store.find(schema_name, namespace)
 
       # Schemas are registered under the full name of the top level Avro record
-      # type.
-      schema_id = @registry.register(schema.fullname, schema)
+      # type, or `subject` if it's provided.
+      schema_id = @registry.register(subject || schema.fullname, schema)
 
       stream = StringIO.new
       writer = Avro::IO::DatumWriter.new(schema)

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -79,7 +79,14 @@ describe AvroTurf::Messaging do
       allow(registry).to receive(:register).and_call_original
       message = { "full_name" => "John Doe" }
       avro.encode(message, schema_name: "person")
-      expect(registry).to have_received(:register)
+      expect(registry).to have_received(:register).with("person", anything)
+    end
+
+    it "allows specifying a schema registry subject" do
+      allow(registry).to receive(:register).and_call_original
+      message = { "full_name" => "John Doe" }
+      avro.encode(message, schema_name: "person", subject: "people")
+      expect(registry).to have_received(:register).with("people", anything)
     end
   end
 


### PR DESCRIPTION
I'm not sure if this is too specific to the Confluent schema registry.