### PR TITLE
Raise error for missing value for a field with no default

### DIFF
--- a/lib/avro_turf/schema_to_avro_patch.rb
+++ b/lib/avro_turf/schema_to_avro_patch.rb
@@ -34,8 +34,19 @@ class AvroTurf
         end
       end
     end
+
+    module DatumReader
+      def read_default_value(field_schema, default_value)
+        if default_value == :no_default
+          raise Avro::AvroError, "Missing data for #{field_schema} with no default"
+        end
+
+        super
+      end
+    end
   end
 end
 
 Avro::Schema::RecordSchema.send(:prepend, AvroTurf::AvroGemPatch::RecordSchema)
 Avro::Schema::Field.send(:prepend, AvroTurf::AvroGemPatch::Field)
+Avro::IO::DatumReader.send(:prepend, AvroTurf::AvroGemPatch::DatumReader)

--- a/spec/schema_to_avro_patch_spec.rb
+++ b/spec/schema_to_avro_patch_spec.rb
@@ -22,3 +22,45 @@ describe Avro::Schema do
     })
   end
 end
+
+
+describe Avro::IO::DatumReader do
+  let(:writer_schema) do
+    Avro::Schema.parse <<-AVSC
+      {
+        "name": "no_default",
+        "type": "record",
+        "fields": [
+          { "type": "string", "name": "one" }
+        ]
+      }
+    AVSC
+  end
+  let(:reader_schema) do
+    Avro::Schema.parse <<-AVSC
+      {
+        "name": "no_default",
+        "type": "record",
+        "fields": [
+          { "type": "string", "name": "one" },
+          { "type": "string", "name": "two" }
+        ]
+      }
+    AVSC
+  end
+
+  it "raises an error for missing fields without a default" do
+    stream = StringIO.new
+    writer = Avro::IO::DatumWriter.new(writer_schema)
+    encoder = Avro::IO::BinaryEncoder.new(stream)
+    writer.write({ 'one' => 'first' }, encoder)
+    encoded = stream.string
+
+    stream = StringIO.new(encoded)
+    decoder = Avro::IO::BinaryDecoder.new(stream)
+    reader = Avro::IO::DatumReader.new(writer_schema, reader_schema)
+    expect do
+      reader.read(decoder)
+    end.to raise_error(Avro::AvroError, 'Missing data for "string" with no default')
+  end
+end


### PR DESCRIPTION
This fixes https://github.com/dasch/avro_turf/issues/46

`Avro::IO::DatumReader` is monkey-patched with a change similar to the one accepted for avro: https://github.com/apache/avro/commit/d7e12314832f1ef58f87d2f5106ac6b49c5a0be9#diff-2799aeca9ed470b47a918ce5bc3e291eR410

CC @banister