### PR TITLE
updates method definition compatible method in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ In addition to encoding and decoding data, you can check whether a schema is com
 with a subject in the registry using the [Compatibility API](http://docs.confluent.io/2.0.0/schema-registry/docs/api.html#compatibility)
 
 ```ruby
-require 'avro_turf/messaging'
+require 'avro_turf/schema_registry'
 
 schema = <<-JSON
 {
@@ -144,7 +144,7 @@ schema = <<-JSON
 }
 JSON
 
-avro = AvroTurf::Messaging.new(registry_url: "http://my-registry:8081/")
+avro = AvroTurf::SchemaRegistry.new(registry_url: "http://my-registry:8081/")
 
 # Returns true if the schema is compatible, false otherwise.
 avro.compatible?("person", schema)


### PR DESCRIPTION
My team noticed that you guys are defining `#compatible?` in the schema_registry class and not the messaging class.  