### PR TITLE
Feature/implement registry schema store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in avro_turf.gemspec
 gemspec
+
+# Used by CircleCI to format RSpec results.
+gem 'rspec_junit_formatter', :git => 'git@github.com:circleci/rspec_junit_formatter.git'

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in avro_turf.gemspec
 gemspec
-
-# Used by CircleCI to format RSpec results.
-gem 'rspec_junit_formatter', :git => 'git@github.com:circleci/rspec_junit_formatter.git'

--- a/avro_turf.gemspec
+++ b/avro_turf.gemspec
@@ -22,11 +22,12 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.2.0"
+  spec.add_development_dependency "rspec", "~> 3.5.0"
   spec.add_development_dependency "fakefs", "~> 0.6.7"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "sinatra"
   spec.add_development_dependency "json_spec"
+  spec.add_development_dependency "rspec_junit_formatter"
 
   spec.post_install_message = %{
 avro_turf v0.8.0 deprecates the names AvroTurf::SchemaRegistry,

--- a/avro_turf.gemspec
+++ b/avro_turf.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "sinatra"
   spec.add_development_dependency "json_spec"
-  spec.add_development_dependency "rspec_junit_formatter"
 
   spec.post_install_message = %{
 avro_turf v0.8.0 deprecates the names AvroTurf::SchemaRegistry,

--- a/lib/avro_turf.rb
+++ b/lib/avro_turf.rb
@@ -2,6 +2,7 @@ require 'avro_turf/version'
 require 'avro'
 require 'json'
 require 'avro_turf/schema_store'
+require 'avro_turf/registry_schema_store'
 require 'avro_turf/core_ext'
 require 'avro_turf/schema_to_avro_patch'
 

--- a/lib/avro_turf/cached_confluent_schema_registry.rb
+++ b/lib/avro_turf/cached_confluent_schema_registry.rb
@@ -2,23 +2,26 @@ require 'avro_turf/confluent_schema_registry'
 
 # Caches registrations and lookups to the schema registry in memory.
 class AvroTurf::CachedConfluentSchemaRegistry
+  extend Forwardable
+  def_delegators :@upstream,
+                 :subjects, :subject_versions, :check, :compatible?,
+                 :global_config, :update_global_config, :subject_config,
+                 :update_subject_config
 
   def initialize(upstream)
     @upstream = upstream
     @schemas_by_id = {}
+    @schemas_by_subject = {}
     @ids_by_schema = {}
-  end
-
-  # Delegate the following methods to the upstream
-  %i(subjects subject_versions subject_version check compatible?
-     global_config update_global_config subject_config update_subject_config).each do |name|
-    define_method(name) do |*args|
-      instance_variable_get(:@upstream).send(name, *args)
-    end
   end
 
   def fetch(id)
     @schemas_by_id[id] ||= @upstream.fetch(id)
+  end
+
+  def subject_version(subject, version = 'latest')
+    @schemas_by_subject[subject] ||=
+      @upstream.subject_version(subject, version)
   end
 
   def register(subject, schema)

--- a/lib/avro_turf/registry_schema_store.rb
+++ b/lib/avro_turf/registry_schema_store.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 class AvroTurf
   class RegistrySchemaStore
     def initialize(registry_url)

--- a/lib/avro_turf/registry_schema_store.rb
+++ b/lib/avro_turf/registry_schema_store.rb
@@ -1,0 +1,33 @@
+class AvroTurf
+  class RegistrySchemaStore
+    def initialize(registry_url)
+      @schemas = {}
+
+      @registry = CachedConfluentSchemaRegistry.new(
+        ConfluentSchemaRegistry.new(registry_url)
+      )
+    end
+
+    def find(name, namespace = nil, version = "latest")
+      fullname = Avro::Name.make_fullname(name, namespace)
+      return @schemas.fetch(fullname) if @schemas.key?(fullname)
+
+      schema = @schemas.fetch(fullname) do
+        json_schema = JSON.parse(
+          @registry.subject_version(fullname, version).fetch('schema')
+        )
+        Avro::Schema.real_parse(json_schema, @schemas)
+      end
+
+      schema
+
+    rescue Excon::Error::NotFound
+      raise AvroTurf::SchemaNotFoundError,
+            "could not find Avro schema in the Registry: `#{fullname}` "
+    end
+
+    def load_schemas!
+      @registry.subjects.each { |subject| find(subject) }
+    end
+  end
+end

--- a/lib/avro_turf/version.rb
+++ b/lib/avro_turf/version.rb
@@ -1,3 +1,3 @@
 class AvroTurf
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
 end

--- a/spec/registry_schema_store_spec.rb
+++ b/spec/registry_schema_store_spec.rb
@@ -1,0 +1,61 @@
+require 'avro_turf/schema_store'
+
+describe AvroTurf::RegistrySchemaStore do
+  subject(:store) { described_class.new("http://reg_store") }
+
+  describe "#find" do
+    subject(:found) { store.find("hello") }
+    context "when shema exists" do
+      before do
+        stub_request(
+          :get, "http://reg_store/subjects/hello/versions/latest"
+        ).to_return(
+          status: 200,
+          body: '{"subject":"hello","version":1,"id":23,"schema":"{\"type\":\"record\",\"name\":\"hello\",\"fields\":[{\"name\":\"hello\",\"type\":\"string\"}]}"}'
+        )
+      end
+
+      it { is_expected.to be_a Avro::Schema }
+    end
+
+    context "when schema is missing" do
+      subject { -> { found } }
+       before do
+        stub_request(
+          :get, "http://reg_store/subjects/hello/versions/latest"
+        ).to_return(status: 404)
+      end
+
+      it { is_expected.to raise_exception AvroTurf::SchemaNotFoundError }
+    end
+  end
+
+  describe "#load_schemas!" do
+    #  Testing the side effect
+    subject { store.instance_variable_get(:@schemas) }
+
+    before do
+       stub_request(:get, "http://reg_store/subjects").
+         to_return(
+          status: 200,
+          body: "[\"foo\", \"bar\"]"
+        )
+
+       stub_request(:get, "http://reg_store/subjects/foo/versions/latest").
+         to_return(
+          status: 200,
+          body: '{"subject":"foo","version":1,"id":23,"schema":"{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}"}'
+        )
+
+       stub_request(:get, "http://reg_store/subjects/bar/versions/latest").
+         to_return(
+          status: 200,
+          body: '{"subject":"bar","version":1,"id":23,"schema":"{\"type\":\"record\",\"name\":\"bar\",\"fields\":[{\"name\":\"bar\",\"type\":\"string\"}]}"}'
+        )
+
+        store.load_schemas!
+    end
+
+    it { is_expected.to include "foo", "bar" }
+  end
+end


### PR DESCRIPTION
Sometimes a producer does not have a local schema and would like to fetch it from remote. Thus,this:

```ruby
require 'avro_turf/messaging'
require 'avro_turf/registry_schema_store'

url = "http://my-registry:8081"

avro = AvroTurf::Messaging.new(
  registry_url: url,
  schema_store: AvroTurf::RegistrySchemaStore.new(url)
)

data = avro.encode({ "world" => "hello" }, schema_name: "hello") # => "\u0000\u0000\u0000\u0000\u0017\n" + "hello"
avro.decode(data) # => {"world"=>"hello"}
```