### PR TITLE
add support for different filetypes

### DIFF
--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -31,10 +31,10 @@ class AvroTurf
     # schemas_path - The String file system path where local schemas are stored.
     # namespace    - The String default schema namespace.
     # logger       - The Logger that should be used to log information (optional).
-    def initialize(registry: nil, registry_url: nil, schema_store: nil, schemas_path: nil, namespace: nil, logger: nil)
+    def initialize(registry: nil, registry_url: nil, schema_store: nil, schemas_path: nil, namespace: nil, logger: nil, filetype: :avsc)
       @logger = logger || Logger.new($stderr)
       @namespace = namespace
-      @schema_store = schema_store || SchemaStore.new(path: schemas_path || DEFAULT_SCHEMAS_PATH)
+      @schema_store = schema_store || SchemaStore.new(path: schemas_path || DEFAULT_SCHEMAS_PATH, filetype: filetype)
       @registry = registry || CachedConfluentSchemaRegistry.new(ConfluentSchemaRegistry.new(registry_url, logger: @logger))
       @schemas_by_id = {}
     end

--- a/lib/avro_turf/schema_store.rb
+++ b/lib/avro_turf/schema_store.rb
@@ -1,6 +1,7 @@
 class AvroTurf::SchemaStore
-  def initialize(path: nil)
+  def initialize(path: nil, filetype: :avsc)
     @path = path or raise "Please specify a schema path"
+    @filetype = filetype
     @schemas = Hash.new
   end
 
@@ -15,7 +16,7 @@ class AvroTurf::SchemaStore
     return @schemas[fullname] if @schemas.key?(fullname)
 
     *namespace, schema_name = fullname.split(".")
-    schema_path = File.join(@path, *namespace, schema_name + ".avsc")
+    schema_path = File.join(@path, *namespace, schema_name + ".#{@filetype}")
     schema_json = JSON.parse(File.read(schema_path))
     schema = Avro::Schema.real_parse(schema_json, @schemas)
 
@@ -42,14 +43,14 @@ class AvroTurf::SchemaStore
 
   # Loads all schema definition files in the `schemas_dir`.
   def load_schemas!
-    pattern = [@path, "**", "*.avsc"].join("/")
+    pattern = [@path, "**", "*.#{@filetype}"].join("/")
 
     Dir.glob(pattern) do |schema_path|
       # Remove the path prefix.
       schema_path.sub!(/^\/?#{@path}\//, "")
 
       # Replace `/` with `.` and chop off the file extension.
-      schema_name = File.basename(schema_path.tr("/", "."), ".avsc")
+      schema_name = File.basename(schema_path.tr("/", "."), ".#{@filetype}")
 
       # Load and cache the schema.
       find(schema_name)

--- a/spec/schema_store_spec.rb
+++ b/spec/schema_store_spec.rb
@@ -1,253 +1,545 @@
 require 'avro_turf/schema_store'
 
 describe AvroTurf::SchemaStore do
-  let(:store) { AvroTurf::SchemaStore.new(path: "spec/schemas") }
-
   before do
     FileUtils.mkdir_p("spec/schemas")
   end
 
   describe "#find" do
-    it "finds schemas on the file system" do
-      define_schema "message.avsc", <<-AVSC
-        {
-          "name": "message",
-          "type": "record",
-          "fields": [
-            {
-              "type": "string",
-              "name": "message"
-            }
-          ]
-        }
-      AVSC
+    subject(:store) { described_class.new(path: "spec/schemas") }
 
-      schema = store.find("message")
-      expect(schema.fullname).to eq "message"
-    end
+    context '.avsc filetype' do
+      it "finds schemas on the file system" do
+        define_schema "message.avsc", <<-AVSC
+          {
+            "name": "message",
+            "type": "record",
+            "fields": [
+              {
+                "type": "string",
+                "name": "message"
+              }
+            ]
+          }
+        AVSC
 
-    it "resolves missing references" do
-      define_schema "person.avsc", <<-AVSC
-        {
-          "name": "person",
-          "type": "record",
-          "fields": [
-            {
-              "name": "address",
-              "type": "address"
-            }
-          ]
-        }
-      AVSC
+        schema = store.find("message")
+        expect(schema.fullname).to eq "message"
+      end
 
-      define_schema "address.avsc", <<-AVSC
-        {
-          "type": "record",
-          "name": "address",
-          "fields": []
-        }
-      AVSC
+      it "resolves missing references" do
+        define_schema "person.avsc", <<-AVSC
+          {
+            "name": "person",
+            "type": "record",
+            "fields": [
+              {
+                "name": "address",
+                "type": "address"
+              }
+            ]
+          }
+        AVSC
 
-      schema = store.find("person")
+        define_schema "address.avsc", <<-AVSC
+          {
+            "type": "record",
+            "name": "address",
+            "fields": []
+          }
+        AVSC
 
-      expect(schema.fullname).to eq "person"
-    end
+        schema = store.find("person")
 
-    it "finds namespaced schemas" do
-      FileUtils.mkdir_p("spec/schemas/test/people")
+        expect(schema.fullname).to eq "person"
+      end
 
-      define_schema "test/people/person.avsc", <<-AVSC
-        {
-          "name": "person",
-          "namespace": "test.people",
-          "type": "record",
-          "fields": [
-            {
-              "name": "address",
-              "type": "test.people.address"
-            }
-          ]
-        }
-      AVSC
+      it "finds namespaced schemas" do
+        FileUtils.mkdir_p("spec/schemas/test/people")
 
-      define_schema "test/people/address.avsc", <<-AVSC
-        {
-          "name": "address",
-          "namespace": "test.people",
-          "type": "record",
-          "fields": []
-        }
-      AVSC
+        define_schema "test/people/person.avsc", <<-AVSC
+          {
+            "name": "person",
+            "namespace": "test.people",
+            "type": "record",
+            "fields": [
+              {
+                "name": "address",
+                "type": "test.people.address"
+              }
+            ]
+          }
+        AVSC
 
-      schema = store.find("person", "test.people")
+        define_schema "test/people/address.avsc", <<-AVSC
+          {
+            "name": "address",
+            "namespace": "test.people",
+            "type": "record",
+            "fields": []
+          }
+        AVSC
 
-      expect(schema.fullname).to eq "test.people.person"
-    end
+        schema = store.find("person", "test.people")
 
-    it "ignores the namespace when the name contains a dot" do
-      FileUtils.mkdir_p("spec/schemas/test/acme")
+        expect(schema.fullname).to eq "test.people.person"
+      end
 
-      define_schema "test/acme/message.avsc", <<-AVSC
-        {
-          "name": "message",
-          "namespace": "test.acme",
-          "type": "record",
-          "fields": []
-        }
-      AVSC
+      it "ignores the namespace when the name contains a dot" do
+        FileUtils.mkdir_p("spec/schemas/test/acme")
 
-      schema = store.find("test.acme.message", "test.yolo")
+        define_schema "test/acme/message.avsc", <<-AVSC
+          {
+            "name": "message",
+            "namespace": "test.acme",
+            "type": "record",
+            "fields": []
+          }
+        AVSC
 
-      expect(schema.fullname).to eq "test.acme.message"
-    end
+        schema = store.find("test.acme.message", "test.yolo")
 
-    it "raises AvroTurf::SchemaNotFoundError if there's no schema file matching the name" do
-      expect {
-        store.find("not_there")
-      }.to raise_error(AvroTurf::SchemaNotFoundError, "could not find Avro schema at `spec/schemas/not_there.avsc'")
-    end
+        expect(schema.fullname).to eq "test.acme.message"
+      end
 
-    it "raises AvroTurf::SchemaNotFoundError if a type reference cannot be resolved" do
-      define_schema "person.avsc", <<-AVSC
-        {
-          "name": "person",
-          "type": "record",
-          "fields": [
-            {
-              "name": "address",
-              "type": "address"
-            }
-          ]
-        }
-      AVSC
+      it "raises AvroTurf::SchemaNotFoundError if there's no schema file matching the name" do
+        expect {
+          store.find("not_there")
+        }.to raise_error(AvroTurf::SchemaNotFoundError, "could not find Avro schema at `spec/schemas/not_there.avsc'")
+      end
 
-      expect {
+      it "raises AvroTurf::SchemaNotFoundError if a type reference cannot be resolved" do
+        define_schema "person.avsc", <<-AVSC
+          {
+            "name": "person",
+            "type": "record",
+            "fields": [
+              {
+                "name": "address",
+                "type": "address"
+              }
+            ]
+          }
+        AVSC
+
+        expect {
+          store.find("person")
+        }.to raise_exception(AvroTurf::SchemaNotFoundError)
+      end
+
+      it "raises AvroTurf::SchemaError if the schema's namespace doesn't match the file location" do
+        FileUtils.mkdir_p("spec/schemas/test/people")
+
+        define_schema "test/people/person.avsc", <<-AVSC
+          {
+            "name": "person",
+            "namespace": "yoyoyo.nanana",
+            "type": "record",
+            "fields": []
+          }
+        AVSC
+
+        expect {
+          store.find("test.people.person")
+        }.to raise_error(AvroTurf::SchemaError, "expected schema `spec/schemas/test/people/person.avsc' to define type `test.people.person'")
+      end
+
+      it "handles circular dependencies" do
+        define_schema "a.avsc", <<-AVSC
+          {
+            "name": "a",
+            "type": "record",
+            "fields": [
+              {
+                "type": "b",
+                "name": "b"
+              }
+            ]
+          }
+        AVSC
+
+        define_schema "b.avsc", <<-AVSC
+          {
+            "name": "b",
+            "type": "record",
+            "fields": [
+              {
+                "type": "a",
+                "name": "a"
+              }
+            ]
+          }
+        AVSC
+
+        schema = store.find("a")
+        expect(schema.fullname).to eq "a"
+      end
+
+      it "caches schemas in memory" do
+        define_schema "person.avsc", <<-AVSC
+          {
+            "name": "person",
+            "type": "record",
+            "fields": [
+              {
+                "type": "string",
+                "name": "full_name"
+              }
+            ]
+          }
+        AVSC
+
+        # Warm the schema cache.
         store.find("person")
-      }.to raise_exception(AvroTurf::SchemaNotFoundError)
+
+        # Force a failure if the schema file is read again.
+        FileUtils.rm("spec/schemas/person.avsc")
+
+        schema = store.find("person")
+        expect(schema.fullname).to eq "person"
+      end
+
+      it 'only finds schemas with the predefined filetype' do
+        define_schema "person.json", <<-JSON
+          {
+            "name": "person",
+            "type": "record",
+            "fields": [
+              {
+                "type": "string",
+                "name": "full_name"
+              }
+            ]
+          }
+        JSON
+
+        expect {
+          store.find("person")
+        }.to raise_exception(AvroTurf::SchemaNotFoundError)
+      end
     end
 
-    it "raises AvroTurf::SchemaError if the schema's namespace doesn't match the file location" do
-      FileUtils.mkdir_p("spec/schemas/test/people")
+    context '.json filetype' do
+      subject(:store) { described_class.new(path: "spec/schemas", filetype: :json) }
 
-      define_schema "test/people/person.avsc", <<-AVSC
-        {
-          "name": "person",
-          "namespace": "yoyoyo.nanana",
-          "type": "record",
-          "fields": []
-        }
-      AVSC
+      it "finds schemas on the file system" do
+        define_schema "message.json", <<-JSON
+          {
+            "name": "message",
+            "type": "record",
+            "fields": [
+              {
+                "type": "string",
+                "name": "message"
+              }
+            ]
+          }
+        JSON
 
-      expect {
-        store.find("test.people.person")
-      }.to raise_error(AvroTurf::SchemaError, "expected schema `spec/schemas/test/people/person.avsc' to define type `test.people.person'")
-    end
+        schema = store.find("message")
+        expect(schema.fullname).to eq "message"
+      end
 
-    it "handles circular dependencies" do
-      define_schema "a.avsc", <<-AVSC
-        {
-          "name": "a",
-          "type": "record",
-          "fields": [
-            {
-              "type": "b",
-              "name": "b"
-            }
-          ]
-        }
-      AVSC
+      it "resolves missing references" do
+        define_schema "person.json", <<-JSON
+          {
+            "name": "person",
+            "type": "record",
+            "fields": [
+              {
+                "name": "address",
+                "type": "address"
+              }
+            ]
+          }
+        JSON
 
-      define_schema "b.avsc", <<-AVSC
-        {
-          "name": "b",
-          "type": "record",
-          "fields": [
-            {
-              "type": "a",
-              "name": "a"
-            }
-          ]
-        }
-      AVSC
+        define_schema "address.json", <<-JSON
+          {
+            "type": "record",
+            "name": "address",
+            "fields": []
+          }
+        JSON
 
-      schema = store.find("a")
-      expect(schema.fullname).to eq "a"
-    end
+        schema = store.find("person")
 
-    it "caches schemas in memory" do
-      define_schema "person.avsc", <<-AVSC
-        {
-          "name": "person",
-          "type": "record",
-          "fields": [
-            {
-              "type": "string",
-              "name": "full_name"
-            }
-          ]
-        }
-      AVSC
+        expect(schema.fullname).to eq "person"
+      end
 
-      # Warm the schema cache.
-      store.find("person")
+      it "finds namespaced schemas" do
+        FileUtils.mkdir_p("spec/schemas/test/people")
 
-      # Force a failure if the schema file is read again.
-      FileUtils.rm("spec/schemas/person.avsc")
+        define_schema "test/people/person.json", <<-JSON
+          {
+            "name": "person",
+            "namespace": "test.people",
+            "type": "record",
+            "fields": [
+              {
+                "name": "address",
+                "type": "test.people.address"
+              }
+            ]
+          }
+        JSON
 
-      schema = store.find("person")
-      expect(schema.fullname).to eq "person"
+        define_schema "test/people/address.json", <<-JSON
+          {
+            "name": "address",
+            "namespace": "test.people",
+            "type": "record",
+            "fields": []
+          }
+        JSON
+
+        schema = store.find("person", "test.people")
+
+        expect(schema.fullname).to eq "test.people.person"
+      end
+
+      it "ignores the namespace when the name contains a dot" do
+        FileUtils.mkdir_p("spec/schemas/test/acme")
+
+        define_schema "test/acme/message.json", <<-JSON
+          {
+            "name": "message",
+            "namespace": "test.acme",
+            "type": "record",
+            "fields": []
+          }
+        JSON
+
+        schema = store.find("test.acme.message", "test.yolo")
+
+        expect(schema.fullname).to eq "test.acme.message"
+      end
+
+      it "raises AvroTurf::SchemaNotFoundError if there's no schema file matching the name" do
+        expect {
+          store.find("not_there")
+        }.to raise_error(AvroTurf::SchemaNotFoundError, "could not find Avro schema at `spec/schemas/not_there.json'")
+      end
+
+      it "raises AvroTurf::SchemaNotFoundError if a type reference cannot be resolved" do
+        define_schema "person.json", <<-JSON
+          {
+            "name": "person",
+            "type": "record",
+            "fields": [
+              {
+                "name": "address",
+                "type": "address"
+              }
+            ]
+          }
+        JSON
+
+        expect {
+          store.find("person")
+        }.to raise_exception(AvroTurf::SchemaNotFoundError)
+      end
+
+      it "raises AvroTurf::SchemaError if the schema's namespace doesn't match the file location" do
+        FileUtils.mkdir_p("spec/schemas/test/people")
+
+        define_schema "test/people/person.json", <<-JSON
+          {
+            "name": "person",
+            "namespace": "yoyoyo.nanana",
+            "type": "record",
+            "fields": []
+          }
+        JSON
+
+        expect {
+          store.find("test.people.person")
+        }.to raise_error(AvroTurf::SchemaError, "expected schema `spec/schemas/test/people/person.json' to define type `test.people.person'")
+      end
+
+      it "handles circular dependencies" do
+        define_schema "a.json", <<-JSON
+          {
+            "name": "a",
+            "type": "record",
+            "fields": [
+              {
+                "type": "b",
+                "name": "b"
+              }
+            ]
+          }
+        JSON
+
+        define_schema "b.json", <<-JSON
+          {
+            "name": "b",
+            "type": "record",
+            "fields": [
+              {
+                "type": "a",
+                "name": "a"
+              }
+            ]
+          }
+        JSON
+
+        schema = store.find("a")
+        expect(schema.fullname).to eq "a"
+      end
+
+      it "caches schemas in memory" do
+        define_schema "person.json", <<-JSON
+          {
+            "name": "person",
+            "type": "record",
+            "fields": [
+              {
+                "type": "string",
+                "name": "full_name"
+              }
+            ]
+          }
+        JSON
+
+        # Warm the schema cache.
+        store.find("person")
+
+        # Force a failure if the schema file is read again.
+        FileUtils.rm("spec/schemas/person.json")
+
+        schema = store.find("person")
+        expect(schema.fullname).to eq "person"
+      end
+
+      it 'only finds schemas with the predefined filetype' do
+        define_schema "person.avsc", <<-AVSC
+          {
+            "name": "person",
+            "type": "record",
+            "fields": [
+              {
+                "type": "string",
+                "name": "full_name"
+              }
+            ]
+          }
+        AVSC
+
+        expect {
+          store.find("person")
+        }.to raise_exception(AvroTurf::SchemaNotFoundError)
+      end
     end
   end
 
   describe "#load_schemas!" do
-    it "loads schemas defined in the `schemas_path` directory" do
-      define_schema "person.avsc", <<-AVSC
-        {
-          "name": "person",
-          "type": "record",
-          "fields": [
-            {
-              "type": "string",
-              "name": "full_name"
-            }
-          ]
-        }
-      AVSC
+    context '.avsc filetype' do
+      subject(:store) { described_class.new(path: "spec/schemas") }
 
-      # Warm the schema cache.
-      store.load_schemas!
+      it "loads schemas defined in the `schemas_path` directory" do
+        define_schema "person.avsc", <<-AVSC
+          {
+            "name": "person",
+            "type": "record",
+            "fields": [
+              {
+                "type": "string",
+                "name": "full_name"
+              }
+            ]
+          }
+        AVSC
 
-      # Force a failure if the schema file is read again.
-      FileUtils.rm("spec/schemas/person.avsc")
+        # Warm the schema cache.
+        store.load_schemas!
 
-      schema = store.find("person")
-      expect(schema.fullname).to eq "person"
+        # Force a failure if the schema file is read again.
+        FileUtils.rm("spec/schemas/person.avsc")
+
+        schema = store.find("person")
+        expect(schema.fullname).to eq "person"
+      end
+
+      it "recursively finds schema definitions in subdirectories" do
+        FileUtils.mkdir_p("spec/schemas/foo/bar")
+
+        define_schema "foo/bar/person.avsc", <<-AVSC
+          {
+            "name": "foo.bar.person",
+            "type": "record",
+            "fields": [
+              {
+                "type": "string",
+                "name": "full_name"
+              }
+            ]
+          }
+        AVSC
+
+        # Warm the schema cache.
+        store.load_schemas!
+
+        # Force a failure if the schema file is read again.
+        FileUtils.rm("spec/schemas/foo/bar/person.avsc")
+
+        schema = store.find("foo.bar.person")
+        expect(schema.fullname).to eq "foo.bar.person"
+      end
     end
 
-    it "recursively finds schema definitions in subdirectories" do
-      FileUtils.mkdir_p("spec/schemas/foo/bar")
+    context '.json filetype' do
+      subject(:store) { described_class.new(path: "spec/schemas", filetype: :json) }
 
-      define_schema "foo/bar/person.avsc", <<-AVSC
-        {
-          "name": "foo.bar.person",
-          "type": "record",
-          "fields": [
-            {
-              "type": "string",
-              "name": "full_name"
-            }
-          ]
-        }
-      AVSC
+      it "loads schemas defined in the `schemas_path` directory" do
+        define_schema "person.json", <<-JSON
+          {
+            "name": "person",
+            "type": "record",
+            "fields": [
+              {
+                "type": "string",
+                "name": "full_name"
+              }
+            ]
+          }
+        JSON
 
-      # Warm the schema cache.
-      store.load_schemas!
+        # Warm the schema cache.
+        store.load_schemas!
 
-      # Force a failure if the schema file is read again.
-      FileUtils.rm("spec/schemas/foo/bar/person.avsc")
+        # Force a failure if the schema file is read again.
+        FileUtils.rm("spec/schemas/person.json")
 
-      schema = store.find("foo.bar.person")
-      expect(schema.fullname).to eq "foo.bar.person"
+        schema = store.find("person")
+        expect(schema.fullname).to eq "person"
+      end
+
+      it "recursively finds schema definitions in subdirectories" do
+        FileUtils.mkdir_p("spec/schemas/foo/bar")
+
+        define_schema "foo/bar/person.json", <<-JSON
+          {
+            "name": "foo.bar.person",
+            "type": "record",
+            "fields": [
+              {
+                "type": "string",
+                "name": "full_name"
+              }
+            ]
+          }
+        JSON
+
+        # Warm the schema cache.
+        store.load_schemas!
+
+        # Force a failure if the schema file is read again.
+        FileUtils.rm("spec/schemas/foo/bar/person.json")
+
+        schema = store.find("foo.bar.person")
+        expect(schema.fullname).to eq "foo.bar.person"
+      end
     end
   end
 end


### PR DESCRIPTION
Add support for specifying the filetype to be used in the schema store when creating store or messaging.

This won't change the default behaviour of `.avsc` being the default filetype, it just enables users to specify different formats when needed.