### PR TITLE
Allow accessing schema store from outside AvroTurf

### DIFF
--- a/lib/avro_turf.rb
+++ b/lib/avro_turf.rb
@@ -10,20 +10,20 @@ class AvroTurf
   class SchemaError < Error; end
   class SchemaNotFoundError < Error; end
 
-  attr_accessor :schema_store
-
   DEFAULT_SCHEMAS_PATH = "./schemas"
 
   # Create a new AvroTurf instance with the specified configuration.
   #
   # schemas_path - The String path to the root directory containing Avro schemas (default: "./schemas").
+  # schema_store - A schema store object that responds to #find(schema_name, namespace).
   # namespace    - The String namespace that should be used to qualify schema names (optional).
   # codec        - The String name of a codec that should be used to compress messages (optional).
   #
   # Currently, the only valid codec name is `deflate`.
-  def initialize(schemas_path: nil, namespace: nil, codec: nil)
+  def initialize(schemas_path: nil, schema_store: nil, namespace: nil, codec: nil)
     @namespace = namespace
-    @schema_store = SchemaStore.new(path: schemas_path || DEFAULT_SCHEMAS_PATH)
+    @schema_store = schema_store || 
+      SchemaStore.new(path: schemas_path || DEFAULT_SCHEMAS_PATH)
     @codec = codec
   end
 

--- a/lib/avro_turf.rb
+++ b/lib/avro_turf.rb
@@ -10,6 +10,8 @@ class AvroTurf
   class SchemaError < Error; end
   class SchemaNotFoundError < Error; end
 
+  attr_accessor :schema_store
+
   DEFAULT_SCHEMAS_PATH = "./schemas"
 
   # Create a new AvroTurf instance with the specified configuration.

--- a/lib/avro_turf/mutable_schema_store.rb
+++ b/lib/avro_turf/mutable_schema_store.rb
@@ -1,0 +1,18 @@
+require 'avro_turf/schema_store'
+
+class AvroTurf
+  # A schema store that allows you to add or remove schemas, and to access
+  # them externally.
+  class MutableSchemaStore < SchemaStore
+    attr_accessor :schemas
+
+    # @param schema_hash [Hash]
+    def add_schema(schema_hash)
+      name = schema_hash['name']
+      namespace = schema_hash['namespace']
+      full_name = Avro::Name.make_fullname(name, namespace)
+      return if @schemas.key?(full_name)
+      Avro::Schema.real_parse(schema_hash, @schemas)
+    end
+  end
+end

--- a/lib/avro_turf/schema_store.rb
+++ b/lib/avro_turf/schema_store.rb
@@ -1,5 +1,4 @@
 class AvroTurf::SchemaStore
-  attr_accessor :schemas
 
   def initialize(path: nil)
     @path = path or raise "Please specify a schema path"
@@ -58,12 +57,4 @@ class AvroTurf::SchemaStore
     end
   end
 
-  # @param schema_hash [Hash]
-  def add_schema(schema_hash)
-    name = schema_hash['name']
-    namespace = schema_hash['namespace']
-    full_name = Avro::Name.make_fullname(name, namespace)
-    return if @schemas.key?(full_name)
-    Avro::Schema.real_parse(schema_hash, @schemas)
-  end
 end

--- a/lib/avro_turf/schema_store.rb
+++ b/lib/avro_turf/schema_store.rb
@@ -1,4 +1,6 @@
 class AvroTurf::SchemaStore
+  attr_accessor :schemas
+
   def initialize(path: nil)
     @path = path or raise "Please specify a schema path"
     @schemas = Hash.new
@@ -54,5 +56,14 @@ class AvroTurf::SchemaStore
       # Load and cache the schema.
       find(schema_name)
     end
+  end
+
+  # @param schema_hash [Hash]
+  def add_schema(schema_hash)
+    name = schema_hash['name']
+    namespace = schema_hash['namespace']
+    full_name = Avro::Name.make_fullname(name, namespace)
+    return if @schemas.key?(full_name)
+    Avro::Schema.real_parse(schema_hash, @schemas)
   end
 end


### PR DESCRIPTION
In our projects we create schemas dynamically (e.g. creating an Avro key schema from a single field in the Avro value schema). Exposing the schema store to calling code allows us to insert these schemas into it without having them defined in the file system.