### PR TITLE
Validate schemas on encode

### DIFF
--- a/lib/avro_turf.rb
+++ b/lib/avro_turf.rb
@@ -49,6 +49,7 @@ class AvroTurf
   # Returns nothing.
   def encode_to_stream(data, schema_name: nil, stream: nil, namespace: @namespace)
     schema = @schema_store.find(schema_name, namespace)
+    Avro::SchemaValidator.validate!(schema, data) if defined?(Avro::SchemaValidator)
     writer = Avro::IO::DatumWriter.new(schema)
 
     dw = Avro::DataFile::Writer.new(stream, writer, schema, @codec)


### PR DESCRIPTION
This is an enhancement to make use of the SchemaValidator defined in the `avro_patches` gem. This will force-validate schemas when encoding to the schema registry. The schema validator is slightly stricter than the actual schema registry (the validator will reject more things than attempted writes to the schema registry will reject). This ensures that messages (and schemas!) are validated before trying to write to the registry.

We have monkey patched this into our own code and have been using it in production for some time.