### PR TITLE
abstracted caching from CachedConfluentSchemaRegistry

### DIFF
--- a/lib/avro_turf/cached_confluent_schema_registry.rb
+++ b/lib/avro_turf/cached_confluent_schema_registry.rb
@@ -1,12 +1,20 @@
 require 'avro_turf/confluent_schema_registry'
+require 'avro_turf/in_memory_cache'
+require 'avro_turf/disk_cache'
 
 # Caches registrations and lookups to the schema registry in memory.
 class AvroTurf::CachedConfluentSchemaRegistry
 
-  def initialize(upstream)
+  # Instantiate a new CachedConfluentSchemaRegistry instance with the given configuration.
+  # By default, uses a provided InMemoryCache to prevent repeated calls to the upstream registry.
+  #
+  # upstream  - The upstream schema registry object that fully responds to all methods in the
+  #             AvroTurf::ConfluentSchemaRegistry interface.
+  # disk_path - Optional path on disk to use the provided DiskCache instead of the default InMemoryCache
+  # cache     - Optional user provided Cache object that responds to all methods in the AvroTurf::InMemoryCache interface.
+  def initialize(upstream, disk_path: nil, cache: nil)
     @upstream = upstream
-    @schemas_by_id = {}
-    @ids_by_schema = {}
+    @cache = cache || create_cache(disk_path)
   end
 
   # Delegate the following methods to the upstream
@@ -18,10 +26,16 @@ class AvroTurf::CachedConfluentSchemaRegistry
   end
 
   def fetch(id)
-    @schemas_by_id[id] ||= @upstream.fetch(id)
+    @cache.lookup_by_id(id) || @cache.store_by_id(id, @upstream.fetch(id))
   end
 
   def register(subject, schema)
-    @ids_by_schema[subject + schema.to_s] ||= @upstream.register(subject, schema)
+    @cache.lookup_by_schema(subject, schema) || @cache.store_by_schema(subject, schema, @upstream.register(subject, schema))
+  end
+
+  private 
+
+  def create_cache(disk_path)
+    disk_path ? AvroTurf::DiskCache.new(disk_path) : AvroTurf::InMemoryCache.new()
   end
 end

--- a/lib/avro_turf/cached_confluent_schema_registry.rb
+++ b/lib/avro_turf/cached_confluent_schema_registry.rb
@@ -10,11 +10,10 @@ class AvroTurf::CachedConfluentSchemaRegistry
   #
   # upstream  - The upstream schema registry object that fully responds to all methods in the
   #             AvroTurf::ConfluentSchemaRegistry interface.
-  # disk_path - Optional path on disk to use the provided DiskCache instead of the default InMemoryCache
   # cache     - Optional user provided Cache object that responds to all methods in the AvroTurf::InMemoryCache interface.
-  def initialize(upstream, disk_path: nil, cache: nil)
+  def initialize(upstream, cache: nil)
     @upstream = upstream
-    @cache = cache || create_cache(disk_path)
+    @cache = cache || AvroTurf::InMemoryCache.new()
   end
 
   # Delegate the following methods to the upstream
@@ -31,11 +30,5 @@ class AvroTurf::CachedConfluentSchemaRegistry
 
   def register(subject, schema)
     @cache.lookup_by_schema(subject, schema) || @cache.store_by_schema(subject, schema, @upstream.register(subject, schema))
-  end
-
-  private 
-
-  def create_cache(disk_path)
-    disk_path ? AvroTurf::DiskCache.new(disk_path) : AvroTurf::InMemoryCache.new()
   end
 end

--- a/lib/avro_turf/disk_cache.rb
+++ b/lib/avro_turf/disk_cache.rb
@@ -1,0 +1,38 @@
+# A cache for the CachedConfluentSchemaRegistry.
+# Extends the InMemoryCache to provide a write-thru to disk for persistent cache.
+class AvroTurf::DiskCache < AvroTurf::InMemoryCache
+
+  def initialize(disk_path)
+    super()
+
+    # load the write-thru cache on startup, if it exists
+    @schemas_by_id_path = File.join(disk_path, 'schemas_by_id.json')
+    @schemas_by_id = JSON.parse(File.read(@schemas_by_id_path)) if File.exist?(@schemas_by_id_path)
+
+    @ids_by_schema_path = File.join(disk_path, 'ids_by_schema.json')
+    @ids_by_schema = JSON.parse(File.read(@ids_by_schema_path)) if File.exist?(@ids_by_schema_path)
+  end
+
+  # override
+  # the write-thru cache (json) does not store keys in numeric format
+  # so, convert id to a string for caching purposes
+  def lookup_by_id(id)
+    super(id.to_s)
+  end
+
+  # override to include write-thru cache after storing result from upstream
+  def store_by_id(id, schema)
+    # must return the value from storing the result (i.e. do not return result from file write)
+    value = super(id.to_s, schema)
+    File.write(@schemas_by_id_path, JSON.pretty_generate(@schemas_by_id))
+    return value
+  end
+
+  # override to include write-thru cache after storing result from upstream
+  def store_by_schema(subject, schema, id)
+    # must return the value from storing the result (i.e. do not return result from file write)
+    value = super
+    File.write(@ids_by_schema_path, JSON.pretty_generate(@ids_by_schema))
+    return value
+  end
+end

--- a/lib/avro_turf/in_memory_cache.rb
+++ b/lib/avro_turf/in_memory_cache.rb
@@ -1,0 +1,27 @@
+# A cache for the CachedConfluentSchemaRegistry.
+# Simply stores the schemas and ids in in-memory hashes.
+class AvroTurf::InMemoryCache
+
+  def initialize
+    @schemas_by_id = {}
+    @ids_by_schema = {}
+  end
+
+  def lookup_by_id(id)
+    @schemas_by_id[id]
+  end
+
+  def store_by_id(id, schema)
+    @schemas_by_id[id] = schema
+  end
+
+  def lookup_by_schema(subject, schema)
+    key = subject + schema.to_s
+    @ids_by_schema[key]
+  end
+
+  def store_by_schema(subject, schema, id)
+    key = subject + schema.to_s
+    @ids_by_schema[key] = id
+  end
+end

--- a/spec/cached_confluent_schema_registry_spec.rb
+++ b/spec/cached_confluent_schema_registry_spec.rb
@@ -16,8 +16,9 @@ describe AvroTurf::CachedConfluentSchemaRegistry do
 
   describe "#fetch" do
     it "caches the result of fetch" do
+      # multiple calls return same result, with only one upstream call
       allow(upstream).to receive(:fetch).with(id).and_return(schema)
-      registry.fetch(id)
+      expect(registry.fetch(id)).to eq(schema)
       expect(registry.fetch(id)).to eq(schema)
       expect(upstream).to have_received(:fetch).exactly(1).times
     end
@@ -27,8 +28,9 @@ describe AvroTurf::CachedConfluentSchemaRegistry do
     let(:subject_name) { "a_subject" }
 
     it "caches the result of register" do
+      # multiple calls return same result, with only one upstream call
       allow(upstream).to receive(:register).with(subject_name, schema).and_return(id)
-      registry.register(subject_name, schema)
+      expect(registry.register(subject_name, schema)).to eq(id)
       expect(registry.register(subject_name, schema)).to eq(id)
       expect(upstream).to have_received(:register).exactly(1).times
     end

--- a/spec/disk_cached_confluent_schema_registry_spec.rb
+++ b/spec/disk_cached_confluent_schema_registry_spec.rb
@@ -4,7 +4,8 @@ require 'avro_turf/test/fake_confluent_schema_registry_server'
 
 describe AvroTurf::CachedConfluentSchemaRegistry do
   let(:upstream) { instance_double(AvroTurf::ConfluentSchemaRegistry) }
-  let(:registry) { described_class.new(upstream, disk_path: "spec/cache") }
+  let(:cache)    { AvroTurf::DiskCache.new("spec/cache")}
+  let(:registry) { described_class.new(upstream, cache: cache) }
   let(:id) { rand(999) }
   let(:schema) do
     {

--- a/spec/disk_cached_confluent_schema_registry_spec.rb
+++ b/spec/disk_cached_confluent_schema_registry_spec.rb
@@ -1,0 +1,111 @@
+require 'webmock/rspec'
+require 'avro_turf/cached_confluent_schema_registry'
+require 'avro_turf/test/fake_confluent_schema_registry_server'
+
+describe AvroTurf::CachedConfluentSchemaRegistry do
+  let(:upstream) { instance_double(AvroTurf::ConfluentSchemaRegistry) }
+  let(:registry) { described_class.new(upstream, disk_path: "spec/cache") }
+  let(:id) { rand(999) }
+  let(:schema) do
+    {
+      type: "record",
+      name: "person",
+      fields: [{ name: "name", type: "string" }]
+    }.to_json
+  end
+
+  let(:city_id) { rand(999) }
+  let(:city_schema) do
+    {
+      type: "record",
+      name: "city",
+      fields: [{ name: "name", type: "string" }]
+    }.to_json
+  end
+
+  before do
+    FileUtils.mkdir_p("spec/cache")
+  end
+
+  describe "#fetch" do
+    let(:cache_before) do
+      {
+        "#{id}" => "#{schema}"
+      }
+    end
+    let(:cache_after) do
+      {
+        "#{id}" => "#{schema}",
+        "#{city_id}" => "#{city_schema}"
+      }
+    end
+
+    # setup the disk cache to avoid performing the upstream fetch
+    before do
+      store_cache("schemas_by_id.json", cache_before)
+    end
+
+    it "uses preloaded disk cache" do
+      # multiple calls return same result, with zero upstream calls
+      allow(upstream).to receive(:fetch).with(id).and_return(schema)
+      expect(registry.fetch(id)).to eq(schema)
+      expect(registry.fetch(id)).to eq(schema)
+      expect(upstream).to have_received(:fetch).exactly(0).times
+      expect(load_cache("schemas_by_id.json")).to eq cache_before
+    end
+
+    it "writes thru to disk cache" do
+      # multiple calls return same result, with only one upstream call
+      allow(upstream).to receive(:fetch).with(city_id).and_return(city_schema)
+      expect(registry.fetch(city_id)).to eq(city_schema)
+      expect(registry.fetch(city_id)).to eq(city_schema)
+      expect(upstream).to have_received(:fetch).exactly(1).times
+      expect(load_cache("schemas_by_id.json")).to eq cache_after
+    end
+  end
+
+  describe "#register" do
+    let(:subject_name) { "a_subject" }
+    let(:cache_before) do
+      {
+        "#{subject_name}#{schema}" => id
+      }
+    end
+
+    let(:city_name) { "a_city" }
+    let(:cache_after) do 
+      {
+        "#{subject_name}#{schema}" => id,
+        "#{city_name}#{city_schema}" => city_id
+      }
+    end
+
+    # setup the disk cache to avoid performing the upstream register
+    before do
+      store_cache("ids_by_schema.json", cache_before)
+    end
+
+    it "uses preloaded disk cache" do
+      # multiple calls return same result, with zero upstream calls
+      allow(upstream).to receive(:register).with(subject_name, schema).and_return(id)
+      expect(registry.register(subject_name, schema)).to eq(id) 
+      expect(registry.register(subject_name, schema)).to eq(id)
+      expect(upstream).to have_received(:register).exactly(0).times
+      expect(load_cache("ids_by_schema.json")).to eq cache_before
+    end
+
+    it "writes thru to disk cache" do
+      # multiple calls return same result, with only one upstream call
+      allow(upstream).to receive(:register).with(city_name, city_schema).and_return(city_id)
+      expect(registry.register(city_name, city_schema)).to eq(city_id)
+      expect(registry.register(city_name, city_schema)).to eq(city_id)
+      expect(upstream).to have_received(:register).exactly(1).times
+      expect(load_cache("ids_by_schema.json")).to eq cache_after
+    end
+  end
+
+  it_behaves_like "a confluent schema registry client" do
+    let(:upstream) { AvroTurf::ConfluentSchemaRegistry.new(registry_url, logger: logger) }
+    let(:registry) { described_class.new(upstream) }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,14 @@ module Helpers
       f.write(content)
     end
   end
+
+  def store_cache(path, hash)
+    File.write(File.join("spec/cache", path), JSON.generate(hash))
+  end
+
+  def load_cache(path)
+    JSON.parse(File.read(File.join("spec/cache", path)))
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
This PR is a fix for issue #71 

Abstracted the caching from the `CachedConfluentSchemaRegistry` and provided a default `InMemoryCache` that duplicates the existing implementation and also an optional `DiskCache` which extends the `InMemoryCache` to provide a write-thru to disk for persistent cache.

Finally, included an option for a user-defined cache implementation.