### PR TITLE
Add documentation for subject argument in AvroTurf::Messaging#encode

### DIFF
--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -46,6 +46,8 @@ class AvroTurf
     # schema_name - The String name of the schema that should be used to encode
     #               the data.
     # namespace   - The namespace of the schema (optional).
+    # subject     - The subject name the schema should be registered under in
+    #               the schema registry (optional).
     #
     # Returns the encoded data as a String.
     def encode(message, schema_name: nil, namespace: @namespace, subject: nil)


### PR DESCRIPTION
This optional parameter was previously undocumented in the method's docstring. This adds a small line explaining what it is for.