### PR TITLE
CI: Drop old configuration file

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,0 @@
-machine:
-  ruby:
-    version: 2.2.0
-    version: 2.0.0


### PR DESCRIPTION
This PR removes an old configuration file from the repository.

If I'm not mistaken, this is a CircleCI 1.0 configuration YAML file.