### PR TITLE
Load avro-patches if installed to silence deprecation errors

### DIFF
--- a/lib/avro_turf.rb
+++ b/lib/avro_turf.rb
@@ -1,3 +1,8 @@
+begin
+  require 'avro-patches'
+rescue LoadError
+  false
+end
 require 'avro_turf/version'
 require 'avro'
 require 'json'


### PR DESCRIPTION
This patch fixes these deprecation warnings

```
/gems/2.5.0/gems/avro-1.8.2/lib/avro/schema.rb:350: warning: constant ::Fixnum is deprecated
gems/2.5.0/gems/avro-1.8.2/lib/avro/schema.rb:350: warning: constant ::Fixnum is deprecated
gems/2.5.0/gems/avro-1.8.2/lib/avro/schema.rb:106: warning: constant ::Fixnum is deprecated
```

when the https://github.com/salsify/avro-patches is installed.

Co-authored-by: Danny Dawson <danny-dawson@cookpad.com>