### PR TITLE
Make ErrorMessages more verbose

### DIFF
--- a/lib/avro_turf/cached_confluent_schema_registry.rb
+++ b/lib/avro_turf/cached_confluent_schema_registry.rb
@@ -20,15 +20,29 @@ class AvroTurf::CachedConfluentSchemaRegistry
   %i(subjects subject_versions subject_version check compatible?
      global_config update_global_config subject_config update_subject_config).each do |name|
     define_method(name) do |*args|
-      instance_variable_get(:@upstream).send(name, *args)
+      ensure_valid_upstream_object do
+        instance_variable_get(:@upstream).send(name, *args)
+      end
     end
   end
 
   def fetch(id)
-    @cache.lookup_by_id(id) || @cache.store_by_id(id, @upstream.fetch(id))
+    ensure_valid_upstream_object do
+      @cache.lookup_by_id(id) || @cache.store_by_id(id, @upstream.fetch(id))
+    end
   end
 
   def register(subject, schema)
-    @cache.lookup_by_schema(subject, schema) || @cache.store_by_schema(subject, schema, @upstream.register(subject, schema))
+    ensure_valid_upstream_object do
+      @cache.lookup_by_schema(subject, schema) || @cache.store_by_schema(subject, schema, @upstream.register(subject, schema))
+    end
+  end
+
+  private
+
+  def ensure_valid_upstream_object
+    yield
+  rescue NoMethodError
+    raise AvroTurf::Error, "Schema registry '#{@upstream}' is not valid" 
   end
 end

--- a/lib/avro_turf/confluent_schema_registry.rb
+++ b/lib/avro_turf/confluent_schema_registry.rb
@@ -5,9 +5,7 @@ class AvroTurf::ConfluentSchemaRegistry
 
   def initialize(url, logger: Logger.new($stdout))
     @logger = logger
-    @connection = Excon.new(url, headers: {
-      "Content-Type" => CONTENT_TYPE,
-    })
+    @url = url
   end
 
   def fetch(id)
@@ -100,7 +98,15 @@ class AvroTurf::ConfluentSchemaRegistry
 
   def request(path, **options)
     options = { expects: 200 }.merge!(options)
-    response = @connection.request(path: path, **options)
+    response = connection.request(path: path, **options)
     JSON.parse(response.body)
+  end
+
+  def connection
+    Excon.new(@url, headers: {
+      "Content-Type" => CONTENT_TYPE,
+    })
+  rescue URI::InvalidURIError
+    raise AvroTurf::Error, "Schema registry URL '#{@url}' is not valid"
   end
 end

--- a/lib/avro_turf/disk_cache.rb
+++ b/lib/avro_turf/disk_cache.rb
@@ -5,11 +5,13 @@ class AvroTurf::DiskCache < AvroTurf::InMemoryCache
   def initialize(disk_path)
     super()
 
+    @disk_path = disk_path
+
     # load the write-thru cache on startup, if it exists
-    @schemas_by_id_path = File.join(disk_path, 'schemas_by_id.json')
+    @schemas_by_id_path = fetch_schemas_by_id_path
     @schemas_by_id = JSON.parse(File.read(@schemas_by_id_path)) if File.exist?(@schemas_by_id_path)
 
-    @ids_by_schema_path = File.join(disk_path, 'ids_by_schema.json')
+    @ids_by_schema_path = fetch_ids_by_schema_path
     @ids_by_schema = JSON.parse(File.read(@ids_by_schema_path)) if File.exist?(@ids_by_schema_path)
   end
 
@@ -34,5 +36,25 @@ class AvroTurf::DiskCache < AvroTurf::InMemoryCache
     value = super
     File.write(@ids_by_schema_path, JSON.pretty_generate(@ids_by_schema))
     return value
+  end
+
+  private
+
+  def fetch_schemas_by_id_path
+    ensure_valid_disk_path do
+      File.join(@disk_path, 'schemas_by_id.json')
+    end
+  end
+
+  def fetch_ids_by_schema_path
+    ensure_valid_disk_path do
+      File.join(@disk_path, 'ids_by_schema.json')
+    end
+  end
+
+  def ensure_valid_disk_path
+    yield
+  rescue TypeError
+    raise AvroTurf::Error, "Path '#{@disk_path}' is not valid" 
   end
 end

--- a/spec/cached_confluent_schema_registry_spec.rb
+++ b/spec/cached_confluent_schema_registry_spec.rb
@@ -5,6 +5,7 @@ require 'avro_turf/test/fake_confluent_schema_registry_server'
 describe AvroTurf::CachedConfluentSchemaRegistry do
   let(:upstream) { instance_double(AvroTurf::ConfluentSchemaRegistry) }
   let(:registry) { described_class.new(upstream) }
+  let(:registry_without_url) { described_class.new(nil) }
   let(:id) { rand(999) }
   let(:schema) do
     {

--- a/spec/confluent_schema_registry_spec.rb
+++ b/spec/confluent_schema_registry_spec.rb
@@ -5,5 +5,6 @@ require 'avro_turf/test/fake_confluent_schema_registry_server'
 describe AvroTurf::ConfluentSchemaRegistry do
   it_behaves_like "a confluent schema registry client" do
     let(:registry) { described_class.new(registry_url, logger: logger) }
+    let(:registry_without_url) { described_class.new(nil, logger: logger) }
   end
 end

--- a/spec/disk_cached_confluent_schema_registry_spec.rb
+++ b/spec/disk_cached_confluent_schema_registry_spec.rb
@@ -6,6 +6,8 @@ describe AvroTurf::CachedConfluentSchemaRegistry do
   let(:upstream) { instance_double(AvroTurf::ConfluentSchemaRegistry) }
   let(:cache)    { AvroTurf::DiskCache.new("spec/cache")}
   let(:registry) { described_class.new(upstream, cache: cache) }
+  let(:empty_cache) { AvroTurf::DiskCache.new(nil) }
+  let(:registry_without_url) { described_class.new(nil, cache: empty_cache) }
   let(:id) { rand(999) }
   let(:schema) do
     {

--- a/spec/support/confluent_schema_registry_context.rb
+++ b/spec/support/confluent_schema_registry_context.rb
@@ -56,6 +56,14 @@ shared_examples_for "a confluent schema registry client" do
         end.to raise_error(Excon::Errors::NotFound)
       end
     end
+
+    context "when registry URL is empty" do
+      it "raises an error" do
+        expect do
+          registry_without_url.fetch(1)
+        end.to raise_error(AvroTurf::Error)
+      end
+    end
   end
 
   describe "#subjects" do


### PR DESCRIPTION
When URL or path were missing, the error message was very confusing and did not really tell the user what is going on.

For instance, an empty or invalid URL on `ConfluentSchemaRegistry` failed with ``URI::InvalidURIError (bad URI(is not URI?): )`` and it is not really understandable what is going on here. With this PR, it will fail with an ``AvroError`` with ``Schema registry URL '' is not valid``.

The same applies to the ``CachedConfluentSchemaRegistry`` and ``DiskCache``.

It is quite some code to change this, especially the changes in ``CachedConfluentSchemaRegistry``, so let me know if this is something you would like to implement at all or maybe solve it in a different way.



