### PR TITLE
Found a strange bug for enum/array-of-records schemas

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
 --require spec_helper
+--format d

--- a/lib/avro_turf/schema_store.rb
+++ b/lib/avro_turf/schema_store.rb
@@ -34,6 +34,10 @@ class AvroTurf::SchemaStore
       # Re-resolve the original schema now that the dependency has been resolved.
       @schemas.delete(fullname)
       find(fullname)
+    elsif e.to_s =~ /"([\w\.]+)" is already in use/
+      # For some reasons the Avro gem complains about inline enum definitions,
+      # which are already in use. Looks like we can safely ignore this.
+      find(fullname)
     else
       raise
     end


### PR DESCRIPTION
Hey there! First things first, thanks for the great work. AvroTurf is an awesome piece of code!

But I experienced a strange bug with a *complex* schema which makes use of the inter-schema linking. Say we have a person schema which refers to an address schema as an array. Everything is fine. The schema is looked up correctly and an encoding/decoding of a message is working flawlessly.

```json
{
    "name": "person",
    "type": "record",
    "fields": [
        {
            "name": "main_address",
            "type": "address"
        },
        {
            "name": "addresses",
            "type": {
                "type": "array",
                "items": "address"
            }
        }
    ]
}
```
```json
{
    "name": "address",
    "type": "record",
    "fields": [
        {
            "name": "city",
            "type": "string"
        }
    ]
}
```

But when we add a simple [enum](https://avro.apache.org/docs/1.8.2/spec.html#Enums) to the person schema, things screw up. 

```json
{
    "name": "person",
    "type": "record",
    "fields": [
        {
            "name": "status",
            "type": {
                "type": "enum",
                "name": "person_status",
                "symbols": [
                    "active",
                    "locked"
                ]
            }
        },
        {
            "name": "main_address",
            "type": "address"
        },
        {
            "name": "addresses",
            "type": {
                "type": "array",
                "items": "address"
            }
        }
    ]
}
```

Then the underlying Avro gem complains with an `Avro::SchemaParseError` that the enum schema is already in use ([see Avro gem source](https://github.com/apache/avro/blob/release-1.8.2/lang/ruby/lib/avro/schema.rb#L410)).

So I added some more specs here to describe my issue in detail. I was able to bypass the *already in use* case for the schema lookup. But encoding/decoding is not working properly. (see the failing spec)

Here comes an additional log output of the error:

```log
NoMethodError (undefined method `map' for nil:NilClass):
/usr/local/bundle/gems/avro-1.8.2/lib/avro/schema.rb:247:in `to_avro'
/usr/local/bundle/bundler/gems/avro_turf-20af12a4093c/lib/avro_turf/schema_to_avro_patch.rb:31:in `to_avro'
/usr/local/bundle/gems/avro-1.8.2/lib/avro/schema.rb:247:in `block in to_avro'
/usr/local/bundle/gems/avro-1.8.2/lib/avro/schema.rb:247:in `map'
/usr/local/bundle/gems/avro-1.8.2/lib/avro/schema.rb:247:in `to_avro'
/usr/local/bundle/gems/avro-1.8.2/lib/avro/schema.rb:179:in `to_s'
/usr/local/bundle/bundler/gems/avro_turf-20af12a4093c/lib/avro_turf/in_memory_cache.rb:19:in `lookup_by_schema'
/usr/local/bundle/bundler/gems/avro_turf-20af12a4093c/lib/avro_turf/cached_confluent_schema_registry.rb:32:in `register'
/usr/local/bundle/bundler/gems/avro_turf-20af12a4093c/lib/avro_turf/messaging.rb:58:in `encode'
```

As a workaround to the issue, I was able to place the array-of-records inline to the person schema. So this errors occurs only for the combination inter-schema linking inside an array AND the definition of an enumerable on the host schema.

---

I would be really thankful for some comments/help to investigate the issue and find a solution for it.