### PR TITLE
Make schema store to be thread safe

### DIFF
--- a/lib/avro_turf/schema_store.rb
+++ b/lib/avro_turf/schema_store.rb
@@ -3,6 +3,7 @@ class AvroTurf::SchemaStore
   def initialize(path: nil)
     @path = path or raise "Please specify a schema path"
     @schemas = Hash.new
+    @mutex = Mutex.new
   end
 
   # Resolves and returns a schema.
@@ -12,33 +13,17 @@ class AvroTurf::SchemaStore
   # Returns an Avro::Schema.
   def find(name, namespace = nil)
     fullname = Avro::Name.make_fullname(name, namespace)
-
+    # Optimistic non-blocking read from @schemas
+    # No sense to lock the resource when all the schemas already loaded
     return @schemas[fullname] if @schemas.key?(fullname)
 
-    *namespace, schema_name = fullname.split(".")
-    schema_path = File.join(@path, *namespace, schema_name + ".avsc")
-    schema_json = JSON.parse(File.read(schema_path))
-    schema = Avro::Schema.real_parse(schema_json, @schemas)
+    # Pessimistic blocking write to @schemas
+    @mutex.synchronize do
+      # Still need to check is the schema already loaded
+      return @schemas[fullname] if @schemas.key?(fullname)
 
-    if schema.respond_to?(:fullname) && schema.fullname != fullname
-      raise AvroTurf::SchemaError, "expected schema `#{schema_path}' to define type `#{fullname}'"
+      load_schema!(fullname, namespace)
     end
-
-    schema
-  rescue ::Avro::SchemaParseError => e
-    # This is a hack in order to figure out exactly which type was missing. The
-    # Avro gem ought to provide this data directly.
-    if e.to_s =~ /"([\w\.]+)" is not a schema we know about/
-      find($1)
-
-      # Re-resolve the original schema now that the dependency has been resolved.
-      @schemas.delete(fullname)
-      find(fullname)
-    else
-      raise
-    end
-  rescue Errno::ENOENT, Errno::ENAMETOOLONG
-    raise AvroTurf::SchemaNotFoundError, "could not find Avro schema at `#{schema_path}'"
   end
 
   # Loads all schema definition files in the `schemas_dir`.
@@ -57,4 +42,34 @@ class AvroTurf::SchemaStore
     end
   end
 
+  private
+
+  # Loads single schema
+  # Such method is not thread-safe, do not call it of from mutex synchronization routine
+  def load_schema!(fullname, namespace = nil)
+    *namespace, schema_name = fullname.split(".")
+    schema_path = File.join(@path, *namespace, schema_name + ".avsc")
+    schema_json = JSON.parse(File.read(schema_path))
+    schema = Avro::Schema.real_parse(schema_json, @schemas)
+
+    if schema.respond_to?(:fullname) && schema.fullname != fullname
+      raise AvroTurf::SchemaError, "expected schema `#{schema_path}' to define type `#{fullname}'"
+    end
+
+    schema
+  rescue ::Avro::SchemaParseError => e
+    # This is a hack in order to figure out exactly which type was missing. The
+    # Avro gem ought to provide this data directly.
+    if e.to_s =~ /"([\w\.]+)" is not a schema we know about/
+      load_schema!($1)
+
+      # Re-resolve the original schema now that the dependency has been resolved.
+      @schemas.delete(fullname)
+      load_schema!(fullname)
+    else
+      raise
+    end
+  rescue Errno::ENOENT, Errno::ENAMETOOLONG
+    raise AvroTurf::SchemaNotFoundError, "could not find Avro schema at `#{schema_path}'"
+  end
 end


### PR DESCRIPTION
It addresses the race condition issue, and makes the `AvroTurf::SchemaStore` to be thread safe.

There is [the issue](https://github.com/dasch/avro_turf/issues/78) describing the same problem.

@dasch 
> These issues only crop on on JRuby :)

I'm able to reproduce it in MRI :) Please look at the test from PR, without the fix it 100% fails with:

```
be rspec
...........................................................................................................F......

Failures:

  1) AvroTurf::SchemaStore#find is thread safe
     Failure/Error: expect {
       expected no Exception, got #<Avro::SchemaParseError: The name "address" is already in use.> with backtrace:
         # ./spec/schema_store_spec.rb:215:in `call'
         # ./spec/schema_store_spec.rb:215:in `block (4 levels) in <top (required)>'
         # ./lib/avro_turf/schema_store.rb:53:in `load_schema!'
         # ./lib/avro_turf/schema_store.rb:25:in `find'
         # ./spec/schema_store_spec.rb:219:in `block (5 levels) in <top (required)>'
     # ./spec/schema_store_spec.rb:223:in `block (3 levels) in <top (required)>'

Finished in 1.28 seconds (files took 0.46095 seconds to load)
114 examples, 1 failure
```