### PR TITLE
Compatibility with Avro v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avro_turf
 
+## Unreleased
+- Compatibility with Avro v1.9.0.
+
 ## v0.8.1
 
 - Allow accessing schema store from outside AvroTurf (#68).

--- a/avro_turf.gemspec
+++ b/avro_turf.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "avro", ">= 1.7.7", "< 1.9"
+  spec.add_dependency "avro", ">= 1.7.7", "< 1.10"
   spec.add_dependency "excon", "~> 0.45"
 
   spec.add_development_dependency "bundler", "~> 1.7"

--- a/lib/avro_turf.rb
+++ b/lib/avro_turf.rb
@@ -8,7 +8,11 @@ require 'avro'
 require 'json'
 require 'avro_turf/schema_store'
 require 'avro_turf/core_ext'
-require 'avro_turf/schema_to_avro_patch'
+
+# check for something that indicates Avro v1.9.0 or later
+unless defined?(::Avro::LogicalTypes)
+  require 'avro_turf/schema_to_avro_patch'
+end
 
 class AvroTurf
   class Error < StandardError; end


### PR DESCRIPTION
Avro v1.9.0 has been released! After 2 years and 1 day since the last release.

To be compatible with the new version, the `schema_to_avro_patch` needs to be excluded.

Unfortunately the official release does not set a version correctly, so instead this change relies on looking for something that was added in v1.9.0.