### PR TITLE
Disable the auto registeration of schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ avro = AvroTurf::Messaging.new(registry_url: "http://my-registry:8081/")
 # time a schema is used.
 data = avro.encode({ "title" => "hello, world" }, schema_name: "greeting")
 
+# If you don't want to automatically register new schemas, you can pass explicitly
+# subject and version to specify which schema should be used for encoding.
+# It will fetch that schema from the registry and cache it. Subsequent instances 
+# of the same schema version will be served by the cache.
+data = avro.encode({ "title" => "hello, world" }, subject: 'greeting', version: 1)
+
 # When decoding, the schema will be fetched from the registry and cached. Subsequent
 # instances of the same schema id will be served by the cache.
 avro.decode(data) #=> { "title" => "hello, world" }

--- a/lib/avro_turf/cached_confluent_schema_registry.rb
+++ b/lib/avro_turf/cached_confluent_schema_registry.rb
@@ -17,7 +17,7 @@ class AvroTurf::CachedConfluentSchemaRegistry
   end
 
   # Delegate the following methods to the upstream
-  %i(subjects subject_versions subject_version check compatible?
+  %i(subjects subject_versions check compatible?
      global_config update_global_config subject_config update_subject_config).each do |name|
     define_method(name) do |*args|
       instance_variable_get(:@upstream).send(name, *args)
@@ -30,5 +30,10 @@ class AvroTurf::CachedConfluentSchemaRegistry
 
   def register(subject, schema)
     @cache.lookup_by_schema(subject, schema) || @cache.store_by_schema(subject, schema, @upstream.register(subject, schema))
+  end
+
+  def subject_version(subject, version = 'latest')
+    @cache.lookup_by_version(subject, version) ||
+      @cache.store_by_version(subject, version, @upstream.subject_version(subject, version))
   end
 end

--- a/lib/avro_turf/in_memory_cache.rb
+++ b/lib/avro_turf/in_memory_cache.rb
@@ -5,6 +5,7 @@ class AvroTurf::InMemoryCache
   def initialize
     @schemas_by_id = {}
     @ids_by_schema = {}
+    @schema_by_subject_version = {}
   end
 
   def lookup_by_id(id)
@@ -23,5 +24,15 @@ class AvroTurf::InMemoryCache
   def store_by_schema(subject, schema, id)
     key = subject + schema.to_s
     @ids_by_schema[key] = id
+  end
+
+  def lookup_by_version(subject, version)
+    key = "#{subject}#{version}"
+    @schema_by_subject_version[key]
+  end
+
+  def store_by_version(subject, version, schema)
+    key = "#{subject}#{version}"
+    @schema_by_subject_version[key] = schema
   end
 end

--- a/lib/avro_turf/test/fake_confluent_schema_registry_server.rb
+++ b/lib/avro_turf/test/fake_confluent_schema_registry_server.rb
@@ -84,6 +84,7 @@ class FakeConfluentSchemaRegistryServer < Sinatra::Base
     {
       name: params[:subject],
       version: schema_ids.index(schema_id) + 1,
+      id: schema_id,
       schema: schema
     }.to_json
   end

--- a/spec/cached_confluent_schema_registry_spec.rb
+++ b/spec/cached_confluent_schema_registry_spec.rb
@@ -36,6 +36,26 @@ describe AvroTurf::CachedConfluentSchemaRegistry do
     end
   end
 
+  describe '#subject_version' do
+    let(:subject_name) { 'a_subject' }
+    let(:version) { 1 }
+    let(:schema_with_meta) do
+      {
+        subject: subject_name,
+        id: 1,
+        version: 1,
+        schema: schema
+      }
+    end
+
+    it 'caches the result of subject_version' do
+      allow(upstream).to receive(:subject_version).with(subject_name, version).and_return(schema_with_meta)
+      registry.subject_version(subject_name, version)
+      registry.subject_version(subject_name, version)
+      expect(upstream).to have_received(:subject_version).exactly(1).times
+    end
+  end
+
   it_behaves_like "a confluent schema registry client" do
     let(:upstream) { AvroTurf::ConfluentSchemaRegistry.new(registry_url, logger: logger) }
     let(:registry) { described_class.new(upstream) }

--- a/spec/support/confluent_schema_registry_context.rb
+++ b/spec/support/confluent_schema_registry_context.rb
@@ -88,16 +88,18 @@ shared_examples_for "a confluent schema registry client" do
   end
 
   describe "#subject_version" do
-    before do
-      2.times do |n|
-        registry.register(subject_name,
-                          { type: :record, name: "r#{n}", fields: [] }.to_json)
-      end
+    let!(:schema_id1) do
+      registry.register(subject_name, { type: :record, name: "r0", fields: [] }.to_json)
     end
+    let!(:schema_id2) do
+      registry.register(subject_name, { type: :record, name: "r1", fields: [] }.to_json)
+    end
+
     let(:expected) do
       {
         name: subject_name,
         version: 1,
+        id: schema_id1,
         schema: { type: :record, name: "r0", fields: [] }.to_json
       }.to_json
     end
@@ -112,6 +114,7 @@ shared_examples_for "a confluent schema registry client" do
         {
           name: subject_name,
           version: 2,
+          id: schema_id2,
           schema: { type: :record, name: "r1", fields: [] }.to_json
         }.to_json
       end


### PR DESCRIPTION
Currently we have to find a schema in schema store (a local folder within avro files) and register them automatically if they don't exist on the schema registry, then use it to encode the message.

In production environment, as [Confluent suggests](https://docs.confluent.io/current/schema-registry/security.html#disabling-auto-schema-registration) it's better to disable the automatic schema registration within the application, which currently it's not supported by AvroTurf.

In our team, we want to have a centralized git repo to manage all schema revisions and schema evaluation, the only way to register a new schema would be create a PR, merge it to master then the deployment will handle the registration and we don't want to let the application automatically register new schemas on the schema registry.

So that means, we have to specify which schema should be used when encoding the message. I add two optional arguments(`subject` and `version`) in `AvroTurf::Messaging#encode` method, if they are provided, it will fetch that schema from the registry and cache it.

In the high level serialiser API, we can always ask producers to pass `subject` and `version` explicitly to prevent the automatic registration on the producer side.