### PR TITLE
Messaging API: Return schema_id and message as result of decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ data = avro.encode({ "title" => "hello, world" }, subject: 'greeting', version: 
 # When decoding, the schema will be fetched from the registry and cached. Subsequent
 # instances of the same schema id will be served by the cache.
 avro.decode(data) #=> { "title" => "hello, world" }
+
+# If you want to get decoded message as well as schema_id used to encode the message,
+# you can use `#decode_message` method.
+result = avro.decode_message(data)
+result.message   #=> { "title" => "hello, world" }
+result.schema_id #=> 3
 ```
 
 ### Confluent Schema Registry Client

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -146,4 +146,114 @@ describe AvroTurf::Messaging do
       expect(schema_store).to have_received(:find).with("person", nil)
     end
   end
+
+  describe 'decoding with #decode_message' do
+    shared_examples_for "encoding and decoding with the schema from schema store" do
+      it "encodes and decodes messages" do
+        data = avro.encode(message, schema_name: "person")
+        result = avro.decode_message(data)
+        expect(result.message).to eq message
+        expect(result.schema_id).to eq 0
+      end
+
+      it "allows specifying a reader's schema" do
+        data = avro.encode(message, schema_name: "person")
+        expect(avro.decode_message(data, schema_name: "person").message).to eq message
+      end
+
+      it "caches parsed schemas for decoding" do
+        data = avro.encode(message, schema_name: "person")
+        avro.decode_message(data)
+        allow(Avro::Schema).to receive(:parse).and_call_original
+        expect(avro.decode_message(data).message).to eq message
+        expect(Avro::Schema).not_to have_received(:parse)
+      end
+    end
+
+    shared_examples_for 'encoding and decoding with the schema from registry' do
+      before do
+        registry = AvroTurf::ConfluentSchemaRegistry.new(registry_url, logger: logger)
+        registry.register('person', Avro::Schema.parse(schema_json))
+        registry.register('people', Avro::Schema.parse(schema_json))
+      end
+
+      it 'encodes and decodes messages' do
+        data = avro.encode(message, subject: 'person', version: 1)
+        result = avro.decode_message(data)
+        expect(result.message).to eq message
+        expect(result.schema_id).to eq 0
+      end
+
+      it "allows specifying a reader's schema by subject and version" do
+        data = avro.encode(message, subject: 'person', version: 1)
+        expect(avro.decode_message(data, schema_name: 'person').message).to eq message
+      end
+
+      it 'raises AvroTurf::SchemaNotFoundError when the schema does not exist on registry' do
+        expect { avro.encode(message, subject: 'missing', version: 1) }.to raise_error(AvroTurf::SchemaNotFoundError)
+      end
+
+      it 'caches parsed schemas for decoding' do
+        data = avro.encode(message, subject: 'person', version: 1)
+        avro.decode_message(data)
+        allow(Avro::Schema).to receive(:parse).and_call_original
+        expect(avro.decode_message(data).message).to eq message
+        expect(Avro::Schema).not_to have_received(:parse)
+      end
+    end
+
+    it_behaves_like "encoding and decoding with the schema from schema store"
+
+    it_behaves_like 'encoding and decoding with the schema from registry'
+
+    context "with a provided registry" do
+      let(:registry) { AvroTurf::ConfluentSchemaRegistry.new(registry_url, logger: logger) }
+
+      let(:avro) do
+        AvroTurf::Messaging.new(
+          registry: registry,
+          schemas_path: "spec/schemas",
+          logger: logger
+        )
+      end
+
+      it_behaves_like "encoding and decoding with the schema from schema store"
+
+      it_behaves_like 'encoding and decoding with the schema from registry'
+
+      it "uses the provided registry" do
+        allow(registry).to receive(:register).and_call_original
+        message = { "full_name" => "John Doe" }
+        avro.encode(message, schema_name: "person")
+        expect(registry).to have_received(:register).with("person", anything)
+      end
+
+      it "allows specifying a schema registry subject" do
+        allow(registry).to receive(:register).and_call_original
+        message = { "full_name" => "John Doe" }
+        avro.encode(message, schema_name: "person", subject: "people")
+        expect(registry).to have_received(:register).with("people", anything)
+      end
+    end
+
+    context "with a provided schema store" do
+      let(:schema_store) { AvroTurf::SchemaStore.new(path: "spec/schemas") }
+
+      let(:avro) do
+        AvroTurf::Messaging.new(
+          registry_url: registry_url,
+          schema_store: schema_store,
+          logger: logger
+        )
+      end
+
+      it_behaves_like "encoding and decoding with the schema from schema store"
+
+      it "uses the provided schema store" do
+        allow(schema_store).to receive(:find).and_call_original
+        avro.encode(message, schema_name: "person")
+        expect(schema_store).to have_received(:find).with("person", nil)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This pull request aims to provide `schema_id` used to encode the message in addition to decoded message as a result of `AvroTurf::Messaging#decode`.

``` ruby
# Before
avro.decode(data) #=> { "title" => "hello, world" }

# After
result = avro.decode(data)
result.message   #=> { "title" => "hello, world" }
result.schema_id #=> 2
```

Together with https://github.com/dasch/avro_turf/pull/100 it allows the functionality of retrying a message.