### PR TITLE
adds disk caching for subject/version schemas

### DIFF
--- a/spec/disk_cached_confluent_schema_registry_spec.rb
+++ b/spec/disk_cached_confluent_schema_registry_spec.rb
@@ -24,6 +24,21 @@ describe AvroTurf::CachedConfluentSchemaRegistry do
     }.to_json
   end
 
+  let(:subject) { 'subject' }
+  let(:version) { rand(999) }
+  let(:subject_version_schema) do
+    {
+      subject: subject,
+      version: version,
+      id: id,
+      schema:  {
+        type: "record",
+        name: "city",
+        fields: { name: "name", type: "string" }
+      }
+    }.to_json
+  end
+
   before do
     FileUtils.mkdir_p("spec/cache")
   end
@@ -102,6 +117,38 @@ describe AvroTurf::CachedConfluentSchemaRegistry do
       expect(registry.register(city_name, city_schema)).to eq(city_id)
       expect(upstream).to have_received(:register).exactly(1).times
       expect(load_cache("ids_by_schema.json")).to eq cache_after
+    end
+  end
+
+  describe "#subject_version" do
+    it "writes thru to disk cache" do
+      # multiple calls return same result, with zero upstream calls
+      allow(upstream).to receive(:subject_version).with(subject, version).and_return(subject_version_schema)
+      expect(File).not_to exist("./spec/cache/schemas_by_subject_version.json")
+
+      expect(registry.subject_version(subject, version)).to eq(subject_version_schema)
+
+      json = JSON.parse(File.read("./spec/cache/schemas_by_subject_version.json"))["#{subject}#{version}"]
+      expect(json).to eq(subject_version_schema)
+
+      expect(registry.subject_version(subject, version)).to eq(subject_version_schema)
+      expect(upstream).to have_received(:subject_version).exactly(1).times
+    end
+
+    it "reads from disk cache and populates mem cache" do
+      allow(upstream).to receive(:subject_version).with(subject, version).and_return(subject_version_schema)
+      key = "#{subject}#{version}"
+      hash = {key => subject_version_schema}
+      cache.send(:write_to_disk_cache, "./spec/cache/schemas_by_subject_version.json", hash)
+
+      cached_schema = cache.instance_variable_get(:@schemas_by_subject_version)
+      expect(cached_schema).to eq({})
+
+      expect(registry.subject_version(subject, version)).to eq(subject_version_schema)
+      expect(upstream).to have_received(:subject_version).exactly(0).times
+
+      cached_schema = cache.instance_variable_get(:@schemas_by_subject_version)
+      expect(cached_schema).to eq({key => subject_version_schema})
     end
   end
 


### PR DESCRIPTION
I needed disk caching for subject/version schemas.  This PR implements that feature.  Let me know if there's any context I can provide or changes I can make to get this merged.