### PR TITLE
Include schemas in decoded message

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,13 @@ data = avro.encode({ "title" => "hello, world" }, schema_id: 2)
 # instances of the same schema id will be served by the cache.
 avro.decode(data) #=> { "title" => "hello, world" }
 
-# If you want to get decoded message as well as schema_id used to encode the message,
+# If you want to get decoded message as well as the schema used to encode the message,
 # you can use `#decode_message` method.
 result = avro.decode_message(data)
-result.message   #=> { "title" => "hello, world" }
-result.schema_id #=> 3
+result.message       #=> { "title" => "hello, world" }
+result.schema_id     #=> 3
+result.writer_schema #=> #<Avro::Schema: ...>
+result.reader_schema #=> nil
 ```
 
 ### Confluent Schema Registry Client

--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -21,7 +21,7 @@ class AvroTurf
   # 1: https://github.com/confluentinc/schema-registry
   class Messaging
     MAGIC_BYTE = [0].pack("C").freeze
-    DecodedMessage = Struct.new(:schema_id, :writers_schema, :readers_schema, :message)
+    DecodedMessage = Struct.new(:schema_id, :writer_schema, :reader_schema, :message)
     private_constant(:DecodedMessage)
 
     # Instantiate a new Messaging instance with the given configuration.

--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -21,7 +21,7 @@ class AvroTurf
   # 1: https://github.com/confluentinc/schema-registry
   class Messaging
     MAGIC_BYTE = [0].pack("C").freeze
-    DecodedMessage = Struct.new(:schema_id, :message)
+    DecodedMessage = Struct.new(:schema_id, :writers_schema, :readers_schema, :message)
     private_constant(:DecodedMessage)
 
     # Instantiate a new Messaging instance with the given configuration.
@@ -134,7 +134,7 @@ class AvroTurf
       reader = Avro::IO::DatumReader.new(writers_schema, readers_schema)
       message = reader.read(decoder)
 
-      DecodedMessage.new(schema_id, message)
+      DecodedMessage.new(schema_id, writers_schema, readers_schema, message)
     rescue Excon::Error::NotFound
       raise SchemaNotFoundError.new("Schema with id: #{schema_id} is not found on registry")
     end

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -29,6 +29,7 @@ describe AvroTurf::Messaging do
       }
     AVSC
   end
+  let(:schema) { Avro::Schema.parse(schema_json) }
 
   before do
     FileUtils.mkdir_p("spec/schemas")
@@ -66,8 +67,8 @@ describe AvroTurf::Messaging do
   shared_examples_for 'encoding and decoding with the schema from registry' do
     before do
       registry = AvroTurf::ConfluentSchemaRegistry.new(registry_url, logger: logger)
-      registry.register('person', Avro::Schema.parse(schema_json))
-      registry.register('people', Avro::Schema.parse(schema_json))
+      registry.register('person', schema)
+      registry.register('people', schema)
     end
 
     it 'encodes and decodes messages' do
@@ -96,8 +97,8 @@ describe AvroTurf::Messaging do
   shared_examples_for 'encoding and decoding with the schema_id from registry' do
     before do
       registry = AvroTurf::ConfluentSchemaRegistry.new(registry_url, logger: logger)
-      registry.register('person', Avro::Schema.parse(schema_json))
-      registry.register('people', Avro::Schema.parse(schema_json))
+      registry.register('person', schema)
+      registry.register('people', schema)
     end
 
     it 'encodes and decodes messages' do
@@ -183,11 +184,16 @@ describe AvroTurf::Messaging do
         result = avro.decode_message(data)
         expect(result.message).to eq message
         expect(result.schema_id).to eq 0
+        expect(result.writers_schema).to eq schema
+        expect(result.readers_schema).to eq nil
       end
 
       it "allows specifying a reader's schema" do
         data = avro.encode(message, schema_name: "person")
-        expect(avro.decode_message(data, schema_name: "person").message).to eq message
+        result = avro.decode_message(data, schema_name: "person")
+        expect(result.message).to eq message
+        expect(result.writers_schema).to eq schema
+        expect(result.readers_schema).to eq schema
       end
 
       it "caches parsed schemas for decoding" do
@@ -202,8 +208,8 @@ describe AvroTurf::Messaging do
     shared_examples_for 'encoding and decoding with the schema from registry' do
       before do
         registry = AvroTurf::ConfluentSchemaRegistry.new(registry_url, logger: logger)
-        registry.register('person', Avro::Schema.parse(schema_json))
-        registry.register('people', Avro::Schema.parse(schema_json))
+        registry.register('person', schema)
+        registry.register('people', schema)
       end
 
       it 'encodes and decodes messages' do

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -184,16 +184,16 @@ describe AvroTurf::Messaging do
         result = avro.decode_message(data)
         expect(result.message).to eq message
         expect(result.schema_id).to eq 0
-        expect(result.writers_schema).to eq schema
-        expect(result.readers_schema).to eq nil
+        expect(result.writer_schema).to eq schema
+        expect(result.reader_schema).to eq nil
       end
 
       it "allows specifying a reader's schema" do
         data = avro.encode(message, schema_name: "person")
         result = avro.decode_message(data, schema_name: "person")
         expect(result.message).to eq message
-        expect(result.writers_schema).to eq schema
-        expect(result.readers_schema).to eq schema
+        expect(result.writer_schema).to eq schema
+        expect(result.reader_schema).to eq schema
       end
 
       it "caches parsed schemas for decoding" do


### PR DESCRIPTION
Similar to #101, this includes the readers and writers schema in
addition to the decoded message and schema ID.

This is useful if you have different schemas in a single Kafka topic
and you want to take different action based on the schema name.

cc @oksanka-blaze 