### PR TITLE
Adding support for client certs- passing them through to Excon

### DIFF
--- a/lib/avro_turf/confluent_schema_registry.rb
+++ b/lib/avro_turf/confluent_schema_registry.rb
@@ -3,13 +3,30 @@ require 'excon'
 class AvroTurf::ConfluentSchemaRegistry
   CONTENT_TYPE = "application/vnd.schemaregistry.v1+json".freeze
 
-  def initialize(url, logger: Logger.new($stdout), proxy: nil)
+  def initialize(
+    url,
+    logger: Logger.new($stdout),
+    proxy: nil,
+    client_cert: nil,
+    client_key: nil,
+    client_key_pass: nil,
+    client_cert_data: nil,
+    client_key_data: nil
+  )
     @logger = logger
     headers = {
       "Content-Type" => CONTENT_TYPE
     }
     headers[:proxy] = proxy if proxy&.present?
-    @connection = Excon.new(url, headers: headers)
+    @connection = Excon.new(
+      url,
+      headers: headers,
+      client_cert: client_cert,
+      client_key: client_key,
+      client_key_pass: client_key_pass,
+      client_cert_data: client_cert_data,
+      client_key_data: client_key_data
+    )
   end
 
   def fetch(id)

--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -26,19 +26,48 @@ class AvroTurf
 
     # Instantiate a new Messaging instance with the given configuration.
     #
-    # registry     - A schema registry object that responds to all methods in the
-    #                AvroTurf::ConfluentSchemaRegistry interface.
-    # registry_url - The String URL of the schema registry that should be used.
-    # schema_store - A schema store object that responds to #find(schema_name, namespace).
-    # schemas_path - The String file system path where local schemas are stored.
-    # namespace    - The String default schema namespace.
-    # logger       - The Logger that should be used to log information (optional).
-    # proxy        - Forward the request via  proxy (optional).
-    def initialize(registry: nil, registry_url: nil, schema_store: nil, schemas_path: nil, namespace: nil, logger: nil, proxy: nil)
+    # registry          - A schema registry object that responds to all methods in the
+    #                     AvroTurf::ConfluentSchemaRegistry interface.
+    # registry_url      - The String URL of the schema registry that should be used.
+    # schema_store      - A schema store object that responds to #find(schema_name, namespace).
+    # schemas_path      - The String file system path where local schemas are stored.
+    # namespace         - The String default schema namespace.
+    # logger            - The Logger that should be used to log information (optional).
+    # proxy             - Forward the request via  proxy (optional).
+    # client_cert       - Name of file containing client certificate (optional).
+    # client_key        - Name of file containing client private key to go with client_cert (optional).
+    # client_key_pass   - Password to go with client_key (optional).
+    # client_cert_data  - In-memory client certificate (optional).
+    # client_key_data   - In-memory client private key to go with client_cert_data (optional).
+    def initialize(
+      registry: nil,
+      registry_url: nil,
+      schema_store: nil,
+      schemas_path: nil,
+      namespace: nil,
+      logger: nil,
+      proxy: nil,
+      client_cert: nil,
+      client_key: nil,
+      client_key_pass: nil,
+      client_cert_data: nil,
+      client_key_data: nil
+    )
       @logger = logger || Logger.new($stderr)
       @namespace = namespace
       @schema_store = schema_store || SchemaStore.new(path: schemas_path || DEFAULT_SCHEMAS_PATH)
-      @registry = registry || CachedConfluentSchemaRegistry.new(ConfluentSchemaRegistry.new(registry_url, logger: @logger, proxy: proxy))
+      @registry = registry || CachedConfluentSchemaRegistry.new(
+        ConfluentSchemaRegistry.new(
+          registry_url,
+          logger: @logger,
+          proxy: proxy,
+          client_cert: client_cert,
+          client_key: client_key,
+          client_key_pass: client_key_pass,
+          client_cert_data: client_cert_data,
+          client_key_data: client_key_data
+        )
+      )
       @schemas_by_id = {}
     end
 

--- a/spec/confluent_schema_registry_spec.rb
+++ b/spec/confluent_schema_registry_spec.rb
@@ -3,7 +3,19 @@ require 'avro_turf/confluent_schema_registry'
 require 'avro_turf/test/fake_confluent_schema_registry_server'
 
 describe AvroTurf::ConfluentSchemaRegistry do
+  let(:client_cert) { "test client cert" }
+  let(:client_key) { "test client key" }
+  let(:client_key_pass) { "test client key password" }
+
   it_behaves_like "a confluent schema registry client" do
-    let(:registry) { described_class.new(registry_url, logger: logger) }
+    let(:registry) {
+      described_class.new(
+        registry_url,
+        logger: logger,
+        client_cert: client_cert,
+        client_key: client_key,
+        client_key_pass: client_key_pass
+      )
+    }
   end
 end

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -4,13 +4,19 @@ require 'avro_turf/test/fake_confluent_schema_registry_server'
 
 describe AvroTurf::Messaging do
   let(:registry_url) { "http://registry.example.com" }
+  let(:client_cert) { "test client cert" }
+  let(:client_key) { "test client key" }
+  let(:client_key_pass) { "test client key password" }
   let(:logger) { Logger.new(StringIO.new) }
 
   let(:avro) {
     AvroTurf::Messaging.new(
       registry_url: registry_url,
       schemas_path: "spec/schemas",
-      logger: logger
+      logger: logger,
+      client_cert: client_cert,
+      client_key: client_key,
+      client_key_pass: client_key_pass
     )
   }
 


### PR DESCRIPTION
Some schema registries require that a client pass in certificates when making API requests.

The networking library (`Excon`) supports client certs.

This code allows users of `AvroTurf` to pass in client certificate information; `AvroTurf` will pass the information through to `Excon`.