### PR TITLE
Critical Bugfix: Stop caching nested sub-schemas.

### DIFF
--- a/lib/avro_turf/schema_store.rb
+++ b/lib/avro_turf/schema_store.rb
@@ -46,26 +46,45 @@ class AvroTurf::SchemaStore
 
   # Loads single schema
   # Such method is not thread-safe, do not call it of from mutex synchronization routine
-  def load_schema!(fullname, namespace = nil)
+  def load_schema!(fullname, namespace = nil, local_schemas_cache = {})
     *namespace, schema_name = fullname.split(".")
     schema_path = File.join(@path, *namespace, schema_name + ".avsc")
     schema_json = JSON.parse(File.read(schema_path))
-    schema = Avro::Schema.real_parse(schema_json, @schemas)
 
+    schema = Avro::Schema.real_parse(schema_json, local_schemas_cache)
+
+    # Don't cache the parsed schema until after its fullname is validated
     if schema.respond_to?(:fullname) && schema.fullname != fullname
       raise AvroTurf::SchemaError, "expected schema `#{schema_path}' to define type `#{fullname}'"
     end
+
+    # Cache only this new top-level schema by its fullname. It's critical
+    # not to make every sub-schema resolvable at the top level here because
+    # multiple different avsc files may define the same sub-schema, and
+    # if we share the @schemas cache across all parsing contexts, the Avro
+    # gem will raise an Avro::SchemaParseError when parsing another avsc
+    # file that contains a subschema with the same fullname as one
+    # encountered previously in a different file:
+    # <Avro::SchemaParseError: The name "foo.bar" is already in use.>
+    # Essentially, the only schemas that should be resolvable in @schemas
+    # are those that have their own .avsc files on disk.
+    @schemas[fullname] = schema
 
     schema
   rescue ::Avro::SchemaParseError => e
     # This is a hack in order to figure out exactly which type was missing. The
     # Avro gem ought to provide this data directly.
     if e.to_s =~ /"([\w\.]+)" is not a schema we know about/
-      load_schema!($1)
+      # Try to first resolve a referenced schema from disk.
+      # If this is successful, the Avro gem will have mutated the
+      # local_schemas_cache, adding all the new schemas it found.
+      load_schema!($1, nil, local_schemas_cache)
 
-      # Re-resolve the original schema now that the dependency has been resolved.
-      @schemas.delete(fullname)
-      load_schema!(fullname)
+      # Attempt to re-parse the original schema now that the dependency
+      # has been resolved and use the now-updated local_schemas_cache to
+      # pick up where we left off.
+      local_schemas_cache.delete(fullname)
+      load_schema!(fullname, nil, local_schemas_cache)
     else
       raise
     end


### PR DESCRIPTION
At Dollar Shave Club, for several years we've been using our own fork of avro_turf with [a much simpler version](https://github.com/dollarshaveclub/avro_turf/commit/2adfc09fc82102ab371a9583fedb5b178babe580) of the patch in this pull request, as none of our applications can function at all using the official release. I felt it was high time to finally contribute a high quality, tested version of our patch upstream.

All our .avsc files embed the sub-schemas for every nested field all the way down the hierarchy, so that the one .avsc file is all that is needed to encode an entire, complex, nested data structure consisting of many different types into Avro. Many of our top-level schemas end up embedding their own copies of the same sub-types. For example, a `Person` and a `Company` might both embed the `Address` schema. We generate these nested .avsc files using [Salsify's delightful avro-builder gem](https://github.com/salsify/avro-builder).

With every official version of avro_turf up to and including 0.11.0, trying to load more than one of these deeply-nested .avsc files will result in the Apache Avro gem raising an exception:
```
#<Avro::SchemaParseError: The name "foo.bar" is already in use.>
```

The reason for this is that AvroTurf::StateStore passes its own internal `@schemas` cache to `Avro::Schema.real_parse` for the Avro gem to directly use as the internal `names` cache as it parses the schema definition tree. The Avro gem mutates this cache in place as it parses, adding to it every named type that it encounters along the way. (Incidentally, this also means that it can pollute the `@schemas` object with partial/invalid data in the event that it ultimately ends up raising a parsing exception, because there is no mechanism for restoring `@schemas` to its original state after a failed call to `Avro::Schema.real_parse`. The patch in this pull request partially mitigates the effects of that behavior as well.)

The solution is to create a new, empty context to pass as the `names` parameter to `Avro::Schema.real_parse`, and only add the one resulting top-level schema it returns to the `@schemas` hash, because only schemas that have their own .avsc file on disk should be resolvable by `AvroTurf::SchemaStore.find`.

Our simple patched version wasn't compatible with having two different .avsc files containing circular references to each other, so I fixed that up and made sure the rest of the test suite still passed. I added lots of descriptive comments along the way.

I also added a couple new test cases:

1. Verify that multiple .avsc files may define their own totally independent sub-schemas having the same fully-qualified name. It's illegal for schemas to define a type using the same fully-qualified name more than once, but it is absolutely acceptable for two independent schemas to each define the same or different types using the same fully-qualified name.

2. Verify that sub-schemas do not get cached in the top level `@schemas` cache inside the schema store. The only schemas that should be resolvable via a call to `AvroTurf::SchemaStore#find` are those that have their own .avsc file on disk.


It is important to note that this does change the behavior of avro_turf's schema store API:

If an application using avro_turf expects to pre-cache all its avsc files and then be able to resolve all the nested sub-schemas directly by calling `store.find('subschema', 'some.namespace')`, those applications will break with this patch. I have no idea if anyone relies upon this incorrect behavior, and there are no existing tests in the rspec suite that expect sub-schemas to be resolvable after caching the top-level schema that embedded them. So, incorporating this change may warrant adding a warning to the README.