### PR TITLE
Extend compatibility to Avro v1.10.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Compatibility with Avro v1.10.x.
+
 ## v1.0.0
 
 - Stop caching nested sub-schemas (#111)

--- a/avro_turf.gemspec
+++ b/avro_turf.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "avro", ">= 1.7.7", "< 1.10"
+  spec.add_dependency "avro", ">= 1.7.7", "< 1.11"
   spec.add_dependency "excon", "~> 0.71"
 
   spec.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
Avro v1.10.0 was just released. No changes were required here for compatibility.