### PR TITLE
Optimize AvroTurf::InMemoryCache#lookup_by_schema memory usage

### DIFF
--- a/lib/avro_turf/disk_cache.rb
+++ b/lib/avro_turf/disk_cache.rb
@@ -31,12 +31,18 @@ class AvroTurf::DiskCache < AvroTurf::InMemoryCache
     return value
   end
 
-  # override to include write-thru cache after storing result from upstream
+  # override to use a json serializable cache key
+  def lookup_by_schema(subject, schema)
+    key = "#{subject}#{schema}"
+    @ids_by_schema[key]
+  end
+
+  # override to use a json serializable cache key and update the file cache
   def store_by_schema(subject, schema, id)
-    # must return the value from storing the result (i.e. do not return result from file write)
-    value = super
+    key = "#{subject}#{schema}"
+    @ids_by_schema[key] = id
     File.write(@ids_by_schema_path, JSON.pretty_generate(@ids_by_schema))
-    return value
+    id
   end
 
   # checks instance var (in-memory cache) for schema

--- a/lib/avro_turf/in_memory_cache.rb
+++ b/lib/avro_turf/in_memory_cache.rb
@@ -17,12 +17,12 @@ class AvroTurf::InMemoryCache
   end
 
   def lookup_by_schema(subject, schema)
-    key = subject + schema.to_s
+    key = [subject, schema.to_s]
     @ids_by_schema[key]
   end
 
   def store_by_schema(subject, schema, id)
-    key = subject + schema.to_s
+    key = [subject, schema.to_s]
     @ids_by_schema[key] = id
   end
 


### PR DESCRIPTION
Profiling our event process pipeline revealed that `AvroTurf::InMemoryCache#lookup_by_schema` was allocating a large amount of memory for cache keys when processing messages with large schemas. The method allocates two strings: one when calling `Avro::Schema#to_s` and one to concatenate the subject with the stringified schema. This PR removes the second allocation by using an array cache key rather than a string cache key. Our application has a monkey patch to `Avro::Schema#to_s` which removes the first allocation that I'm working on contributing that back to the avro project.

I had to undo this optimization in `AvroTurf::DiskCache` to ensure the cache data structure can be serialized as JSON and also to avoid breaking the cache file format.