### PR TITLE
Let Messaging#fetch_schema_by_id use the schemas_by_id cache as well to improve encoding performance when the schema ID is given

### DIFF
--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -194,8 +194,10 @@ class AvroTurf
 
     # Fetch the schema from registry with the provided schema_id.
     def fetch_schema_by_id(schema_id)
-      schema_json = @registry.fetch(schema_id)
-      schema = Avro::Schema.parse(schema_json)
+      schema = @schemas_by_id.fetch(schema_id) do
+        schema_json = @registry.fetch(schema_id)
+        Avro::Schema.parse(schema_json)
+      end
       [schema, schema_id]
     end
 


### PR DESCRIPTION
:wave: When benchmarking encoding performance using the Messaging API, I noticed a large chunk of time was actually spent decoding JSON.

```
 %self      total      self      wait     child     calls  name                           location
 16.91     22.505    22.505     0.000     0.000    10000   JSON::Ext::Parser#parse        
 10.83     54.014    14.411     0.000    39.603  2290000  *Class#new                      
  8.25     11.113    10.972     0.000     0.141   500000   <Module::Avro::Name>#make_fullname /Users/lourens/.gem/ruby/2.7.1/gems/avro-1.10.0/lib/avro/schema.rb:586
  5.76      7.659     7.659     0.000     0.000   700000   StringIO#write                 
  5.32      7.075     7.075     0.000     0.000  1160000   Avro::SchemaValidator::Result#initialize /Users/lourens/.gem/ruby/2.7.1/gems/avro-1.10.0/lib/avro/schema_validator.rb:29
  4.88      6.487     6.487     0.000     0.000   570000   Integer#chr                    
  4.75    102.952     6.324     0.000    96.628   490000  *Array#each                     
  3.46      4.604     4.604     0.000     0.000   770016   Symbol#to_s                    
  3.31     64.450     4.406     0.000    60.045   500000  *Avro::IO::DatumWriter#write_data /Users/lourens/.gem/ruby/2.7.1/gems/avro-1.10.0/lib/avro/io.rb:522
```

```
Comparison:
                json_encoding:    257995.3 i/s 
                json_decoding:     75654.1 i/s - 3.41x  slower
                avro_decoding:     13601.4 i/s - 18.97x  slower
                avro_encoding:      1552.7 i/s - 166.16x  slower <<<<<<<<<<<<<<<
avro_encoding_with_validation:      1298.7 i/s - 198.65x  slower
```

I then noticed decoding uses the `schemas_by_id` cache, which is ignored for encoding paths and as such `Avro::Schema.parse` is invoked a lot.

With this PR, same workload:

```
 %self      total      self      wait     child     calls  name                           location
 10.19      0.976     0.164     0.000     0.812    84000   <Class::Avro::SchemaValidator>#validate! /Users/lourens/src/github.com/Shopify/cdc/avro/lang/ruby/pkg/avro-1.11.0.pre1/lib/avro/schema_validator.rb:72
  8.38      0.476     0.135     0.000     0.341    90000   <Class::Avro::SchemaValidator>#validate_simple /Users/lourens/src/github.com/Shopify/cdc/avro/lang/ruby/pkg/avro-1.11.0.pre1/lib/avro/schema_validator.rb:118
  8.09      0.131     0.131     0.000     0.000    70000   StringIO#write                 
  6.16      0.118     0.100     0.000     0.018    99000   Class#new                      
  4.66      1.587     0.075     0.000     1.512    50000  *Avro::IO::DatumWriter#write_data /Users/lourens/src/github.com/Shopify/cdc/avro/lang/ruby/pkg/avro-1.11.0.pre1/lib/avro/io.rb:527
  4.57      0.275     0.074     0.000     0.201    40000   Avro::IO::BinaryEncoder#write_long /Users/lourens/src/github.com/Shopify/cdc/avro/lang/ruby/pkg/avro-1.11.0.pre1/lib/avro/io.rb:197
  3.97      0.503     0.064     0.000     0.438    40000  *<Class::Avro::SchemaValidator>#validate_recursive /Users/lourens/src/github.com/Shopify/cdc/avro/lang/ruby/pkg/avro-1.11.0.pre1/lib/avro/schema_validator.rb:88
  3.93      0.087     0.063     0.000     0.024   130000   <Class::Avro::SchemaValidator>#resolve_datum /Users/lourens/src/github.com/Shopify/cdc/avro/lang/ruby/pkg/avro-1.11.0.pre1/lib/avro/schema_validator.rb:150
  3.60      1.571     0.058     0.000     1.513    25000  *Array#each                     
  3.50      0.056     0.056     0.000     0.000    16000   String#inspect 
```

```
Comparison:
                json_encoding:    247994.3 i/s 
                json_decoding:     75796.6 i/s - 3.27x  slower
                avro_decoding:     13788.1 i/s - 17.99x  slower
                avro_encoding:      3966.5 i/s - 62.52x  slower <<<<<<<<<<<<<<<
avro_encoding_with_validation:      2447.4 i/s - 101.33x  slower
```