### PR TITLE
Prefer writing the magic byte and schema ID directly to the StringIO stream for messaging API encoding

### DIFF
--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -115,10 +115,10 @@ class AvroTurf
       encoder = Avro::IO::BinaryEncoder.new(stream)
 
       # Always start with the magic byte.
-      encoder.write(MAGIC_BYTE)
+      stream.write(MAGIC_BYTE)
 
       # The schema id is encoded as a 4-byte big-endian integer.
-      encoder.write([schema_id].pack("N"))
+      stream.write([schema_id].pack("N"))
 
       # The actual message comes last.
       writer.write(message, encoder)


### PR DESCRIPTION
Skips some indirection through `Avro::IO::DatumWriter` which isn't strictly needed - see https://github.com/apache/avro/blob/master/lang/ruby/lib/avro/io.rb#L232-L235