### PR TITLE
Let schema ID encoding for the messaging API be 0 alloc beyond the first use of a schema

### DIFF
--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -75,6 +75,7 @@ class AvroTurf
         )
       )
       @schemas_by_id = {}
+      @encoded_schema_ids = {}
     end
 
     # Encodes a message using the specified schema.
@@ -118,7 +119,10 @@ class AvroTurf
       encoder.write(MAGIC_BYTE)
 
       # The schema id is encoded as a 4-byte big-endian integer.
-      encoder.write([schema_id].pack("N"))
+      encoded_schema_id = @encoded_schema_ids.fetch(schema_id) do
+        @encoded_schema_ids[schema_id] = [schema_id].pack("N").freeze
+      end
+      encoder.write(encoded_schema_id)
 
       # The actual message comes last.
       writer.write(message, encoder)


### PR DESCRIPTION
Typically most Schema IDs in the encoding path would be heavily reused and can be considered "almost" constant, yet `Array#pack` to encode the schema IDs is quite allocation heavy for `[schema_id].pack("N").freeze`

Current (1x Array, 1x template string, 1x encoded String)

```
 %self      total      self      wait     child     calls  name                           location
 66.67      3.000     2.000     0.000     1.000        1   Object#profile                 test_profile.rb:6
 33.33      1.000     1.000     0.000     0.000        1   Array#pack                     <internal:pack>:133
```

Encoded schema ID cache (0 alloc):

```
 %self      total      self      wait     child     calls  name                           location
   NaN      0.000     0.000     0.000     0.000        1   Object#profile                 test_profile.rb:6
```

```ruby
require 'ruby-prof'

RubyProf.measure_mode = RubyProf::ALLOCATIONS

def profile
  result = RubyProf.profile { yield }
  printer = RubyProf::FlatPrinter.new(result)
  printer.print(STDOUT)
end

profile { [20].pack("N") }

h = {}
h[20] = [20].pack("N").freeze

profile { h[20] }
```

Memory overhead is negligible and a few 10s of bytes depending on the number of schemas in use over process lifetime (inline array or st table backed Hash), but negates some Ruby heap churn of transient objects for what essentially resolves to a constant encoded value.

```
irb(main):008:0> h = {}
irb(main):009:0> ObjectSpace.memsize_of(h)
=> 40
irb(main):010:0> h[20] = [20].pack("N").freeze
irb(main):011:0> ObjectSpace.memsize_of(h)
=> 168
irb(main):012:0> h[25] = [25].pack("N").freeze
irb(main):013:0> ObjectSpace.memsize_of(h)
=> 168
```