### PR TITLE
Prevent CachedConfluentSchemaRegistry from caching the 'latest' version.

### DIFF
--- a/lib/avro_turf/cached_confluent_schema_registry.rb
+++ b/lib/avro_turf/cached_confluent_schema_registry.rb
@@ -33,6 +33,8 @@ class AvroTurf::CachedConfluentSchemaRegistry
   end
 
   def subject_version(subject, version = 'latest')
+    return @upstream.subject_version(subject, version) if version == 'latest'
+    
     @cache.lookup_by_version(subject, version) ||
       @cache.store_by_version(subject, version, @upstream.subject_version(subject, version))
   end


### PR DESCRIPTION
Fixes the problem with long-running code that uses CachedConfluentSchemaRegistry and:
- Initialises an `Avro::Messaging`,  
  calls `Messaging#fetch_schema(subject: 'my-example-value', version 'latest')`,  
  which calls `CachedConfluentSchemaRegistry#subject_version(subject, version)`, then
- Later, does another `fetch_schema(subject: 'my-example-value', version: 'latest')`,  
  … and gets back the same schema, even if it's changed since.

This shortcuts the process when the special `'latest'` version is asked for, never asking the cache to look up or store the result.

(Fixes https://github.com/dasch/avro_turf/issues/130; I opted not to spread the 'latest' version string into the cache code itself, which isn't currently aware of it.)