### PR TITLE
Validate data against schema before encoding in the AvroTurf#encode interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add ability to validate message before encoding in `AvroTurf#encode` interface
+
 ## v1.3.1
 
 - Prevent CachedConfluentSchemaRegistry from caching the 'latest' version (#140)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ avro.decode(encoded_data, schema_name: "person")
 
 # Encode some data using the named schema.
 avro.encode({ "name" => "Jane", "age" => 28 }, schema_name: "person")
+
+# Data can be validated before encoding to get a description of problem through
+# Avro::SchemaValidator::ValidationError exception
+avro.encode({ "titl" => "hello, world" }, schema_name: "person", validate: true)
 ```
 
 ### Inter-schema references


### PR DESCRIPTION
Validation of data has been added only for `Messaging#encode` method, but it'd be good to have this possibility also for base `AvroTurf#encode`. This PR uses the same approach which was introduced in #118 to validate a message before encoding using the `Avro::SchemaValidator` class.