### PR TITLE
Allow working with schemas with references from Schema Registry

### DIFF
--- a/lib/avro_turf/cached_confluent_schema_registry.rb
+++ b/lib/avro_turf/cached_confluent_schema_registry.rb
@@ -33,8 +33,8 @@ class AvroTurf::CachedConfluentSchemaRegistry
     @cache.lookup_by_id(cache_id) || @cache.store_by_id(cache_id, @upstream.fetch_subject_version(id))
   end
 
-  def register(subject, schema)
-    @cache.lookup_by_schema(subject, schema) || @cache.store_by_schema(subject, schema, @upstream.register(subject, schema))
+  def register(subject, schema, refs = [])
+    @cache.lookup_by_schema(subject, schema) || @cache.store_by_schema(subject, schema, @upstream.register(subject, schema, refs))
   end
 
   def subject_version(subject, version = 'latest')

--- a/lib/avro_turf/cached_confluent_schema_registry.rb
+++ b/lib/avro_turf/cached_confluent_schema_registry.rb
@@ -28,6 +28,11 @@ class AvroTurf::CachedConfluentSchemaRegistry
     @cache.lookup_by_id(id) || @cache.store_by_id(id, @upstream.fetch(id))
   end
 
+  def fetch_subject_version(id)
+    cache_id = "#{id}-sv"
+    @cache.lookup_by_id(cache_id) || @cache.store_by_id(cache_id, @upstream.fetch_subject_version(id))
+  end
+
   def register(subject, schema)
     @cache.lookup_by_schema(subject, schema) || @cache.store_by_schema(subject, schema, @upstream.register(subject, schema))
   end

--- a/lib/avro_turf/confluent_schema_registry.rb
+++ b/lib/avro_turf/confluent_schema_registry.rb
@@ -44,8 +44,8 @@ class AvroTurf::ConfluentSchemaRegistry
     get("/schemas/ids/#{id}/versions").first
   end
 
-  def register(subject, schema)
-    data = post("/subjects/#{subject}/versions", body: { schema: schema.to_s }.to_json)
+  def register(subject, schema, refs = [])
+    data = post("/subjects/#{subject}/versions", body: { schema: schema.to_s, references: refs }.to_json)
 
     id = data.fetch("id")
 

--- a/lib/avro_turf/confluent_schema_registry.rb
+++ b/lib/avro_turf/confluent_schema_registry.rb
@@ -39,6 +39,11 @@ class AvroTurf::ConfluentSchemaRegistry
     data.fetch("schema")
   end
 
+  def fetch_subject_version(id)
+    @logger.info "Fetching subject-version pair for schema with id #{id}"
+    get("/schemas/ids/#{id}/versions").first
+  end
+
   def register(subject, schema)
     data = post("/subjects/#{subject}/versions", body: { schema: schema.to_s }.to_json)
 

--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -197,7 +197,6 @@ class AvroTurf
         acc[ref_subject] = ref_schema
         acc
       end
-      
       schema = Avro::Schema.real_parse(MultiJson.load(schema_data.fetch('schema')), names)
       [schema, schema_id]
     end
@@ -213,9 +212,9 @@ class AvroTurf
 
     # Schemas are registered under the full name of the top level Avro record
     # type, or `subject` if it's provided.
-    def register_schema(schema_name:, subject: nil, namespace: nil)
+    def register_schema(schema_name:, subject: nil, namespace: nil, references: [])
       schema = @schema_store.find(schema_name, namespace)
-      schema_id = @registry.register(subject || schema.fullname, schema)
+      schema_id = @registry.register(subject || schema.fullname, schema, references)
       [schema, schema_id]
     end
   end

--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -170,8 +170,9 @@ class AvroTurf
       schema_id = decoder.read(4).unpack("N").first
 
       writers_schema = @schemas_by_id.fetch(schema_id) do
-        schema_json = @registry.fetch(schema_id)
-        @schemas_by_id[schema_id] = Avro::Schema.parse(schema_json)
+        schema_meta = @registry.fetch_subject_version(schema_id)
+        schema, _id = fetch_schema(subject: schema_meta.fetch("subject"), version: schema_meta.fetch("version"))
+        @schemas_by_id[schema_id] = schema
       end
 
       reader = Avro::IO::DatumReader.new(writers_schema, readers_schema)
@@ -188,7 +189,16 @@ class AvroTurf
     def fetch_schema(subject:, version: 'latest')
       schema_data = @registry.subject_version(subject, version)
       schema_id = schema_data.fetch('id')
-      schema = Avro::Schema.parse(schema_data.fetch('schema'))
+      # preload all references as names
+      references = schema_data.fetch('references', [])
+      names = references.inject({}) do |acc, ref|
+        ref_subject = ref.fetch('subject')
+        ref_schema, _ = fetch_schema(subject: ref_subject, version: ref.fetch('version'))
+        acc[ref_subject] = ref_schema
+        acc
+      end
+      
+      schema = Avro::Schema.real_parse(MultiJson.load(schema_data.fetch('schema')), names)
       [schema, schema_id]
     end
 

--- a/lib/avro_turf/test/fake_confluent_schema_registry_server.rb
+++ b/lib/avro_turf/test/fake_confluent_schema_registry_server.rb
@@ -58,6 +58,13 @@ class FakeConfluentSchemaRegistryServer < Sinatra::Base
     { schema: schema }.to_json
   end
 
+  get "/schemas/ids/:schema_id/versions" do
+    schema = SCHEMAS.at(params[:schema_id].to_i)
+    halt(404, SCHEMA_NOT_FOUND) unless schema
+    subject = JSON.parse(schema)["name"]
+    [{ subject: subject, version: 1 }].to_json
+  end
+
   get "/subjects" do
     SUBJECTS.keys.to_json
   end

--- a/spec/cached_confluent_schema_registry_spec.rb
+++ b/spec/cached_confluent_schema_registry_spec.rb
@@ -29,7 +29,7 @@ describe AvroTurf::CachedConfluentSchemaRegistry do
 
     it "caches the result of register" do
       # multiple calls return same result, with only one upstream call
-      allow(upstream).to receive(:register).with(subject_name, schema).and_return(id)
+      allow(upstream).to receive(:register).with(subject_name, schema, []).and_return(id)
       expect(registry.register(subject_name, schema)).to eq(id)
       expect(registry.register(subject_name, schema)).to eq(id)
       expect(upstream).to have_received(:register).exactly(1).times
@@ -44,6 +44,7 @@ describe AvroTurf::CachedConfluentSchemaRegistry do
         subject: subject_name,
         id: 1,
         version: 1,
+        references: [],
         schema: schema
       }
     end

--- a/spec/disk_cached_confluent_schema_registry_spec.rb
+++ b/spec/disk_cached_confluent_schema_registry_spec.rb
@@ -147,7 +147,7 @@ describe AvroTurf::CachedConfluentSchemaRegistry do
 
     it "writes thru to disk cache" do
       # multiple calls return same result, with only one upstream call
-      allow(upstream).to receive(:register).with(city_name, city_schema).and_return(city_id)
+      allow(upstream).to receive(:register).with(city_name, city_schema, []).and_return(city_id)
       expect(registry.register(city_name, city_schema)).to eq(city_id)
       expect(registry.register(city_name, city_schema)).to eq(city_id)
       expect(upstream).to have_received(:register).exactly(1).times
@@ -170,7 +170,7 @@ describe AvroTurf::CachedConfluentSchemaRegistry do
 
     it "skips zero length disk cache" do
       # multiple calls return same result, with only one upstream call
-      allow(upstream).to receive(:register).with(subject_name, schema).and_return(id)
+      allow(upstream).to receive(:register).with(subject_name, schema, []).and_return(id)
       expect(registry.register(subject_name, schema)).to eq(id)
       expect(registry.register(subject_name, schema)).to eq(id)
       expect(upstream).to have_received(:register).exactly(1).times

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -37,6 +37,27 @@ describe AvroTurf::Messaging do
   end
   let(:schema) { Avro::Schema.parse(schema_json) }
 
+  let(:book_message) { { "author" => { "full_name" => "John Doe" }, "title" => "Awesome Book" } }
+  let(:book_schema_json) do
+    <<-AVSC
+      {
+        "name": "book",
+        "type": "record",
+        "fields": [
+          {
+            "type": "string",
+            "name": "title"
+          },
+          {
+            "type": "person",
+            "name": "author"
+          }
+        ]
+      }
+    AVSC
+  end
+  let(:book_schema) { Avro::Schema.real_parse(MultiJson.load(book_schema_json), {"person" => schema}) }
+
   before do
     FileUtils.mkdir_p("spec/schemas")
   end
@@ -72,14 +93,20 @@ describe AvroTurf::Messaging do
 
   shared_examples_for 'encoding and decoding with the schema from registry' do
     before do
-      registry = AvroTurf::ConfluentSchemaRegistry.new(registry_url, logger: logger)
+      registry = AvroTurf::ConfluentSchemaRegistry.new(registry_url, logger: logger) #avro.instance_variable_get("@registry")
       registry.register('person', schema)
       registry.register('people', schema)
+      registry.register('book', book_schema_json, [{"name" => "person", "subject" => "person", "version" => 1}])
     end
 
     it 'encodes and decodes messages' do
       data = avro.encode(message, subject: 'person', version: 1)
       expect(avro.decode(data)).to eq message
+    end
+
+    it 'encodes and decodes messages with references' do
+      data = avro.encode(book_message, subject: 'book', version: 1)
+      expect(avro.decode(data)).to eq book_message
     end
 
     it "allows specifying a reader's schema by subject and version" do
@@ -152,14 +179,14 @@ describe AvroTurf::Messaging do
       allow(registry).to receive(:register).and_call_original
       message = { "full_name" => "John Doe" }
       avro.encode(message, schema_name: "person")
-      expect(registry).to have_received(:register).with("person", anything)
+      expect(registry).to have_received(:register).with("person", anything, [])
     end
 
     it "allows specifying a schema registry subject" do
       allow(registry).to receive(:register).and_call_original
       message = { "full_name" => "John Doe" }
       avro.encode(message, schema_name: "person", subject: "people")
-      expect(registry).to have_received(:register).with("people", anything)
+      expect(registry).to have_received(:register).with("people", anything, [])
     end
   end
 
@@ -266,14 +293,14 @@ describe AvroTurf::Messaging do
         allow(registry).to receive(:register).and_call_original
         message = { "full_name" => "John Doe" }
         avro.encode(message, schema_name: "person")
-        expect(registry).to have_received(:register).with("person", anything)
+        expect(registry).to have_received(:register).with("person", anything, [])
       end
 
       it "allows specifying a schema registry subject" do
         allow(registry).to receive(:register).and_call_original
         message = { "full_name" => "John Doe" }
         avro.encode(message, schema_name: "person", subject: "people")
-        expect(registry).to have_received(:register).with("people", anything)
+        expect(registry).to have_received(:register).with("people", anything, [])
       end
     end
 
@@ -376,7 +403,7 @@ describe AvroTurf::Messaging do
         subject { avro.register_schema(schema_name: schema_name, namespace: namespace) }
 
         before do
-          allow(registry).to receive(:register).with(schema.fullname, schema).and_return(schema_id)
+          allow(registry).to receive(:register).with(schema.fullname, schema, []).and_return(schema_id)
         end
 
         it 'registers schema in registry' do
@@ -390,7 +417,7 @@ describe AvroTurf::Messaging do
         let(:subj) { 'subject' }
 
         before do
-          allow(registry).to receive(:register).with(subj, schema).and_return(schema_id)
+          allow(registry).to receive(:register).with(subj, schema, []).and_return(schema_id)
         end
 
         it 'registers schema in registry' do

--- a/spec/support/confluent_schema_registry_context.rb
+++ b/spec/support/confluent_schema_registry_context.rb
@@ -100,6 +100,7 @@ shared_examples_for "a confluent schema registry client" do
         name: subject_name,
         version: 1,
         id: schema_id1,
+        references: [],
         schema: { type: :record, name: "r0", fields: [] }.to_json
       }.to_json
     end
@@ -115,6 +116,7 @@ shared_examples_for "a confluent schema registry client" do
           name: subject_name,
           version: 2,
           id: schema_id2,
+          references: [],
           schema: { type: :record, name: "r1", fields: [] }.to_json
         }.to_json
       end


### PR DESCRIPTION
While Avro Schema Registry supports references, avro_turf fails to encode/decode/register such kind of schemas.
