### PR TITLE
Add compatibility with Avro v1.11.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add CA cert file option (#157)
+- Add compatibility with Avro v1.11.x.
 
 ## v1.4.1
 

--- a/avro_turf.gemspec
+++ b/avro_turf.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "avro", ">= 1.7.7", "< 1.11"
+  spec.add_dependency "avro", ">= 1.7.7", "< 1.12"
   spec.add_dependency "excon", "~> 0.71"
 
   spec.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
Avro v1.11.0 was released yesterday (Oct 27, 2021).