### PR TITLE
Add rubygems_mfa_required metadata to gemspec

### DIFF
--- a/avro_turf.gemspec
+++ b/avro_turf.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/dasch/avro_turf"
   spec.license       = "MIT"
 
+  spec.metadata["rubygems_mfa_required"] = "true"
+
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
I was going to open an issue to request a new release that includes compatibility with Avro v1.11 (#159).

Then I thought it would be good also include this option to make this gem more secure: https://guides.rubygems.org/mfa-requirement-opt-in/
