### PR TITLE
BC break: Do not patch the global environment and use a Refinement for the #to_avro methods

### DIFF
--- a/avro_turf.gemspec
+++ b/avro_turf.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 2.1'
+
   spec.add_dependency "avro", ">= 1.7.7", "< 1.12"
   spec.add_dependency "excon", "~> 0.71"
 

--- a/lib/avro_turf.rb
+++ b/lib/avro_turf.rb
@@ -15,6 +15,7 @@ unless defined?(::Avro::LogicalTypes)
 end
 
 class AvroTurf
+  using CoreExt
   class Error < StandardError; end
   class SchemaError < Error; end
   class SchemaNotFoundError < Error; end

--- a/lib/avro_turf/core_ext.rb
+++ b/lib/avro_turf/core_ext.rb
@@ -1,10 +1,65 @@
-require 'avro_turf/core_ext/string'
-require 'avro_turf/core_ext/numeric'
-require 'avro_turf/core_ext/enumerable'
-require 'avro_turf/core_ext/hash'
-require 'avro_turf/core_ext/time'
-require 'avro_turf/core_ext/date'
-require 'avro_turf/core_ext/symbol'
-require 'avro_turf/core_ext/nil_class'
-require 'avro_turf/core_ext/true_class'
-require 'avro_turf/core_ext/false_class'
+class AvroTurf
+  module CoreExt
+    refine(String) do
+      def as_avro
+        self
+      end
+    end
+
+    refine(Numeric) do
+      def as_avro
+        self
+      end
+    end
+
+    refine(Enumerable) do
+      def as_avro
+        map(&:as_avro)
+      end
+    end
+
+    refine(Hash) do
+      def as_avro
+        hsh = Hash.new
+        each { |k, v| hsh[k.as_avro] = v.as_avro }
+        hsh
+      end
+    end
+
+    refine(Time) do
+      def as_avro
+        iso8601
+      end
+    end
+
+    refine(Date) do
+      def as_avro
+        iso8601
+      end
+    end
+
+    refine(Symbol) do
+      def as_avro
+        to_s
+      end
+    end
+
+    refine(NilClass) do
+      def as_avro
+        self
+      end
+    end
+
+    refine(TrueClass) do
+      def as_avro
+        self
+      end
+    end
+
+    refine(FalseClass) do
+      def as_avro
+        self
+      end
+    end
+  end
+end

--- a/lib/avro_turf/core_ext/date.rb
+++ b/lib/avro_turf/core_ext/date.rb
@@ -1,5 +1,0 @@
-class Date
-  def as_avro
-    iso8601
-  end
-end

--- a/lib/avro_turf/core_ext/enumerable.rb
+++ b/lib/avro_turf/core_ext/enumerable.rb
@@ -1,5 +1,0 @@
-module Enumerable
-  def as_avro
-    map(&:as_avro)
-  end
-end

--- a/lib/avro_turf/core_ext/false_class.rb
+++ b/lib/avro_turf/core_ext/false_class.rb
@@ -1,5 +1,0 @@
-class FalseClass
-  def as_avro
-    self
-  end
-end

--- a/lib/avro_turf/core_ext/hash.rb
+++ b/lib/avro_turf/core_ext/hash.rb
@@ -1,7 +1,0 @@
-class Hash
-  def as_avro
-    hsh = Hash.new
-    each {|k, v| hsh[k.as_avro] = v.as_avro }
-    hsh
-  end
-end

--- a/lib/avro_turf/core_ext/nil_class.rb
+++ b/lib/avro_turf/core_ext/nil_class.rb
@@ -1,5 +1,0 @@
-class NilClass
-  def as_avro
-    self
-  end
-end

--- a/lib/avro_turf/core_ext/numeric.rb
+++ b/lib/avro_turf/core_ext/numeric.rb
@@ -1,5 +1,0 @@
-class Numeric
-  def as_avro
-    self
-  end
-end

--- a/lib/avro_turf/core_ext/string.rb
+++ b/lib/avro_turf/core_ext/string.rb
@@ -1,5 +1,0 @@
-class String
-  def as_avro
-    self
-  end
-end

--- a/lib/avro_turf/core_ext/symbol.rb
+++ b/lib/avro_turf/core_ext/symbol.rb
@@ -1,5 +1,0 @@
-class Symbol
-  def as_avro
-    to_s
-  end
-end

--- a/lib/avro_turf/core_ext/time.rb
+++ b/lib/avro_turf/core_ext/time.rb
@@ -1,5 +1,0 @@
-class Time
-  def as_avro
-    iso8601
-  end
-end

--- a/lib/avro_turf/core_ext/true_class.rb
+++ b/lib/avro_turf/core_ext/true_class.rb
@@ -1,5 +1,0 @@
-class TrueClass
-  def as_avro
-    self
-  end
-end

--- a/spec/core_ext/date_spec.rb
+++ b/spec/core_ext/date_spec.rb
@@ -1,3 +1,5 @@
+using AvroTurf::CoreExt
+
 describe Date, "#as_avro" do
   it "returns an ISO8601 string describing the time" do
     date = Date.today

--- a/spec/core_ext/enumerable_spec.rb
+++ b/spec/core_ext/enumerable_spec.rb
@@ -1,3 +1,5 @@
+using AvroTurf::CoreExt
+
 describe Enumerable, "#as_avro" do
   it "returns an array" do
     expect(Set.new.as_avro).to eq []

--- a/spec/core_ext/false_class_spec.rb
+++ b/spec/core_ext/false_class_spec.rb
@@ -1,3 +1,5 @@
+using AvroTurf::CoreExt
+
 describe FalseClass, "#as_avro" do
   it "returns itself" do
     expect(false.as_avro).to eq false

--- a/spec/core_ext/hash_spec.rb
+++ b/spec/core_ext/hash_spec.rb
@@ -1,3 +1,5 @@
+using AvroTurf::CoreExt
+
 describe Hash, "#as_avro" do
   it "coerces the keys and values to Avro" do
     x = double(as_avro: "x")

--- a/spec/core_ext/nil_class_spec.rb
+++ b/spec/core_ext/nil_class_spec.rb
@@ -1,3 +1,5 @@
+using AvroTurf::CoreExt
+
 describe NilClass, "#as_avro" do
   it "returns itself" do
     expect(nil.as_avro).to eq nil

--- a/spec/core_ext/numeric_spec.rb
+++ b/spec/core_ext/numeric_spec.rb
@@ -1,3 +1,5 @@
+using AvroTurf::CoreExt
+
 describe Numeric, "#as_avro" do
   it "returns the number itself" do
     expect(42.as_avro).to eq 42

--- a/spec/core_ext/string_spec.rb
+++ b/spec/core_ext/string_spec.rb
@@ -1,3 +1,5 @@
+using AvroTurf::CoreExt
+
 describe String, "#as_avro" do
   it "returns itself" do
     expect("hello".as_avro).to eq "hello"

--- a/spec/core_ext/symbol_spec.rb
+++ b/spec/core_ext/symbol_spec.rb
@@ -1,3 +1,5 @@
+using AvroTurf::CoreExt
+
 describe Symbol, "#as_avro" do
   it "returns the String representation of the Symbol" do
     expect(:hello.as_avro).to eq("hello")

--- a/spec/core_ext/time_spec.rb
+++ b/spec/core_ext/time_spec.rb
@@ -1,3 +1,5 @@
+using AvroTurf::CoreExt
+
 describe Time, "#as_avro" do
   it "returns an ISO8601 string describing the time" do
     time = Time.now

--- a/spec/core_ext/true_class_spec.rb
+++ b/spec/core_ext/true_class_spec.rb
@@ -1,3 +1,5 @@
+using AvroTurf::CoreExt
+
 describe TrueClass, "#as_avro" do
   it "returns itself" do
     expect(true.as_avro).to eq true


### PR DESCRIPTION
This PR contains two BC breaks:
- The gem does not patch the environment by defining the `to_avro` method on some builtin types.
- The gem thus requires Ruby >= 2.1 which is the version in which the refinements were added.

I don't think these two breaks in compatibility will really affect anyone as:
- Ruby 2.1 is EOL since a long time ago
- Users should not rely on this `to_avro` much. But if they do, they can add `using AvroTurf::CoreExt` on the top of each file that uses the method and it will work as well as before.