### PR TITLE
Added extra params for the validation message schema before encode

### DIFF
--- a/lib/avro_turf.rb
+++ b/lib/avro_turf.rb
@@ -77,7 +77,7 @@ class AvroTurf
     writer = Avro::IO::DatumWriter.new(schema)
 
     if validate
-      Avro::SchemaValidator.validate!(schema, data, validate_options)
+      Avro::SchemaValidator.validate!(schema, data, **validate_options)
     end
 
     dw = Avro::DataFile::Writer.new(stream, writer, schema, @codec)

--- a/spec/avro_turf_spec.rb
+++ b/spec/avro_turf_spec.rb
@@ -251,6 +251,31 @@ describe AvroTurf do
           expect { encode_to_stream }.to raise_error(Avro::SchemaValidator::ValidationError, /extra field 'fulll_name'/)
         end
       end
+
+      context "when message contains extra fields" do
+        let(:message) { { "full_name" => "John Doe", "first_name" => "John", "last_name" => "Doe" } }
+        subject(:encode_to_stream) do
+          stream = StringIO.new
+          avro.encode_to_stream(message, stream: stream, schema_name: "message",
+                                validate: true,
+                                validate_options: { recursive: true, encoded: false, fail_on_extra_fields: false }
+          )
+        end
+
+        it "should not raise Avro::SchemaValidator::ValidationError with a message about extra field" do
+          define_schema "message.avsc", <<-AVSC
+            {
+              "name": "message",
+              "type": "record",
+              "fields": [
+                { "name": "full_name", "type": "string" }
+              ]
+            }
+          AVSC
+
+          expect { encode_to_stream }.not_to raise_error
+        end
+      end
     end
   end
 

--- a/spec/avro_turf_spec.rb
+++ b/spec/avro_turf_spec.rb
@@ -252,7 +252,7 @@ describe AvroTurf do
         end
       end
 
-      context "when message contains extra fields" do
+      context "when the `fail_on_extra_fields` validation option is disabled" do
         let(:message) { { "full_name" => "John Doe", "first_name" => "John", "last_name" => "Doe" } }
         subject(:encode_to_stream) do
           stream = StringIO.new


### PR DESCRIPTION
Parameter `validate: false`  changes default validation params for the  `Avro::SchemaValidator` and we don't have any option to manage the validation option.
Main goal for this PR - it is allow disable new introduced validation option `fail_on_extra_fields: true` when `validate: true` is enabled.