### PR TITLE
Have DiskCache implement InMemoryCache interface without inheritance

### DIFF
--- a/lib/avro_turf/disk_cache.rb
+++ b/lib/avro_turf/disk_cache.rb
@@ -8,19 +8,11 @@ class AvroTurf::DiskCache
     # load the write-thru cache on startup, if it exists
     @schemas_by_id_path = File.join(disk_path, 'schemas_by_id.json')
     hash = read_from_disk_cache(@schemas_by_id_path)
-    @schemas_by_id = if hash
-                       hash
-                     else
-                       {}
-                     end
+    @schemas_by_id = hash || {}
 
     @ids_by_schema_path = File.join(disk_path, 'ids_by_schema.json')
     hash = read_from_disk_cache(@ids_by_schema_path)
-    @ids_by_schema = if hash
-                       hash
-                     else
-                       {}
-                     end
+    @ids_by_schema = hash || {}
 
     @schemas_by_subject_version_path = File.join(disk_path, 'schemas_by_subject_version.json')
     @schemas_by_subject_version = {}

--- a/lib/avro_turf/disk_cache.rb
+++ b/lib/avro_turf/disk_cache.rb
@@ -1,20 +1,26 @@
 # A cache for the CachedConfluentSchemaRegistry.
 # Extends the InMemoryCache to provide a write-thru to disk for persistent cache.
-class AvroTurf::DiskCache < AvroTurf::InMemoryCache
+class AvroTurf::DiskCache
 
   def initialize(disk_path, logger: Logger.new($stdout))
-    super()
-
     @logger = logger
 
     # load the write-thru cache on startup, if it exists
     @schemas_by_id_path = File.join(disk_path, 'schemas_by_id.json')
     hash = read_from_disk_cache(@schemas_by_id_path)
-    @schemas_by_id = hash if hash
+    @schemas_by_id = if hash
+                       hash
+                     else
+                       {}
+                     end
 
     @ids_by_schema_path = File.join(disk_path, 'ids_by_schema.json')
     hash = read_from_disk_cache(@ids_by_schema_path)
-    @ids_by_schema = hash if hash
+    @ids_by_schema = if hash
+                       hash
+                     else
+                       {}
+                     end
 
     @schemas_by_subject_version_path = File.join(disk_path, 'schemas_by_subject_version.json')
     @schemas_by_subject_version = {}
@@ -24,15 +30,16 @@ class AvroTurf::DiskCache < AvroTurf::InMemoryCache
   # the write-thru cache (json) does not store keys in numeric format
   # so, convert id to a string for caching purposes
   def lookup_by_id(id)
-    super(id.to_s)
+    @schemas_by_id[id.to_s]
   end
 
   # override to include write-thru cache after storing result from upstream
   def store_by_id(id, schema)
     # must return the value from storing the result (i.e. do not return result from file write)
-    value = super(id.to_s, schema)
+    @schemas_by_id[id.to_s] = schema
     File.write(@schemas_by_id_path, JSON.pretty_generate(@schemas_by_id))
-    return value
+
+    schema
   end
 
   # override to use a json serializable cache key
@@ -46,6 +53,7 @@ class AvroTurf::DiskCache < AvroTurf::InMemoryCache
     key = "#{subject}#{schema}"
     @ids_by_schema[key] = id
     File.write(@ids_by_schema_path, JSON.pretty_generate(@ids_by_schema))
+
     id
   end
 
@@ -78,7 +86,7 @@ class AvroTurf::DiskCache < AvroTurf::InMemoryCache
              hash[key] = schema
              hash
            else
-             {key => schema}
+             { key => schema }
            end
 
     write_to_disk_cache(@schemas_by_subject_version_path, hash)
@@ -90,7 +98,7 @@ class AvroTurf::DiskCache < AvroTurf::InMemoryCache
   # Parse the file from disk, if it exists and is not zero length
   private def read_from_disk_cache(path)
     if File.exist?(path)
-      if File.size(path)!=0
+      if File.size(path) != 0
         return JSON.parse(File.read(path))
       else
         # just log a message if skipping zero length file


### PR DESCRIPTION
The current implementation was accessing instance variables from parent class and was expecting different contracts about them (type of the key was not the same).
Also, there was a different naming for schemas_by_subject_version