### PR TITLE
Fixed problem with the cache file truncation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Unreleased
 
+- Fixed schema file cache truncation on multiple running instances and parallel access to the cache files.
+
 ## v1.7.0
 
-- Added extra params for the validation message schem before encode (#169)
+- Added extra params for the validation message schema before encode (#169)
 - Fix infinite retry when loading schema with nested primary type in separate file (#165)
 
 ## v1.6.0
@@ -60,7 +62,7 @@
 ## v0.9.0
 
 - Compatibility with Avro v1.9.0 (#94)
-- Disable the auto registeration of schema (#95)
+- Disable the auto registration of schema (#95)
 - abstracted caching from CachedConfluentSchemaRegistry (#74)
 - Load avro-patches if installed to silence deprecation errors (#85)
 - Make schema store to be thread safe (#92)

--- a/spec/disk_cached_confluent_schema_registry_spec.rb
+++ b/spec/disk_cached_confluent_schema_registry_spec.rb
@@ -60,6 +60,7 @@ describe AvroTurf::CachedConfluentSchemaRegistry do
     # setup the disk cache to avoid performing the upstream fetch
     before do
       store_cache("schemas_by_id.json", cache_before)
+
     end
 
     it "uses preloaded disk cache" do

--- a/spec/disk_cached_confluent_schema_registry_spec.rb
+++ b/spec/disk_cached_confluent_schema_registry_spec.rb
@@ -60,7 +60,6 @@ describe AvroTurf::CachedConfluentSchemaRegistry do
     # setup the disk cache to avoid performing the upstream fetch
     before do
       store_cache("schemas_by_id.json", cache_before)
-
     end
 
     it "uses preloaded disk cache" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,16 @@ module Helpers
   end
 end
 
+# gem `fakefs` does not support flock for the file, and require patch
+# https://github.com/fakefs/fakefs/issues/433
+module FakeFS
+  class File < StringIO
+    def flock(*)
+      true
+    end
+  end
+end
+
 RSpec.configure do |config|
   config.include FakeFS::SpecHelpers
   config.include Helpers


### PR DESCRIPTION
We expired erros with the cache file truncation when multiply processes doing read and write at the same time on hight loading system. 
File.write opens the file with the 'w' mode and it do file truncation based on the official documentation.
A solution to fix this problem - use file lock on write.