### PR TITLE
allow date to be passed as-is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- add support for `Date` via appropriate logicalType defintion.  This is a backwards incompatible change  (#177)
+
 ## v1.7.0
 
 - Added extra params for the validation message schem before encode (#169)

--- a/lib/avro_turf/core_ext/date.rb
+++ b/lib/avro_turf/core_ext/date.rb
@@ -1,5 +1,5 @@
 class Date
   def as_avro
-    iso8601
+    self
   end
 end

--- a/spec/avro_turf_spec.rb
+++ b/spec/avro_turf_spec.rb
@@ -16,6 +16,13 @@ describe AvroTurf do
               {
                 "type": "string",
                 "name": "full_name"
+              },
+              {
+                "name": "birth_date",
+                "type": {
+                  "type": "int",
+                  "logicalType": "date"
+                }
               }
             ]
           }
@@ -24,7 +31,8 @@ describe AvroTurf do
 
       it "encodes data with Avro" do
         data = {
-          "full_name" => "John Doe"
+          "full_name" => "John Doe",
+          "birth_date" => Date.new(1934, 1, 2)
         }
 
         encoded_data = avro.encode(data, schema_name: "person")
@@ -36,7 +44,8 @@ describe AvroTurf do
         compressed_avro = AvroTurf.new(schemas_path: "spec/schemas/", codec: "deflate")
 
         data = {
-          "full_name" => "John Doe" * 100
+          "full_name" => "John Doe" * 100,
+          "birth_date" => Date.new(1934, 1, 2)
         }
 
         uncompressed_data = avro.encode(data, schema_name: "person")
@@ -327,6 +336,34 @@ describe AvroTurf do
       AVSC
 
       datum = { message: "hello" }
+      expect(avro.valid?(datum, schema_name: "postcard")).to eq true
+    end
+
+    it "handles logicalType of date in schema" do
+      define_schema "postcard.avsc", <<-AVSC
+        {
+          "name": "postcard",
+          "type": "record",
+          "fields": [
+            {
+              "name": "message",
+              "type": "string"
+            },
+            {
+              "name": "sent_date",
+              "type": {
+                "type": "int",
+                "logicalType": "date"
+              }
+            }
+          ]
+        }
+      AVSC
+
+      datum = { 
+        message: "hello",
+        sent_date: Date.new(2022, 9, 11)
+      }
       expect(avro.valid?(datum, schema_name: "postcard")).to eq true
     end
   end

--- a/spec/core_ext/date_spec.rb
+++ b/spec/core_ext/date_spec.rb
@@ -1,6 +1,6 @@
 describe Date, "#as_avro" do
-  it "returns an ISO8601 string describing the time" do
+  it "returns Date object describing the time" do
     date = Date.today
-    expect(date.as_avro).to eq(date.iso8601)
+    expect(date.as_avro).to eq(date)
   end
 end


### PR DESCRIPTION
This is a straight forward fix to allow `date` to be used in avroturf by using the following schema definition of a date via logicalType;
```
"type": {
  "type": "int",
  "logicalType": "date"
}
```

Updated `spec/avro_turf_spec.rb` to demonstrate the usage of logicalType for `date`.