### PR TITLE
Add Ruby 3.1 and 3.2 to CI and get CI to green

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,17 +7,17 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        ruby: [2.6, 2.7, 3.0]
+        ruby: [2.6, 2.7, "3.0", 3.1, 3.2]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby ${{ matrix.ruby }}
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
     - name: Build and test with RSpec
       run: |
-        gem install bundler
-        bundle install --jobs 4 --retry 3
         bundle exec rspec

--- a/avro_turf.gemspec
+++ b/avro_turf.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.2"
-  spec.add_development_dependency "fakefs", "~> 0.20.0"
+  spec.add_development_dependency "fakefs", "< 3"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "sinatra"
   spec.add_development_dependency "json_spec"


### PR DESCRIPTION
Changes include:

1. Quoting the `3.0` to ensure that it is not truncated, and that a Ruby `3.0` version is loaded for this entry in the matrix
2. Updating the checkout action to v3
3. Using the built-in`bundler-cache` for `setup-ruby` rather than installing bundler separately (prevents potential bundler version issues)
4. Loosened the `fakefs` development dependency 

Everything runs green on my fork, and Ruby 3.1 and 3.2 are now tested.