### PR TITLE
Use Excon default headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Unreleased
 
+- Send Accept and User-Agent headers on every request (#184)
+
 ## v1.8.0
 
-- add support for `Date` via appropriate logicalType defintion.  This is a backwards incompatible change  (#177)
+- Add support for `Date` via appropriate logicalType defintion.  This is a backwards incompatible change  (#177)
 - Fixed schema file cache truncation on multiple running instances and parallel access to the cache files.
 
 ## v1.7.0

--- a/lib/avro_turf/confluent_schema_registry.rb
+++ b/lib/avro_turf/confluent_schema_registry.rb
@@ -19,9 +19,9 @@ class AvroTurf::ConfluentSchemaRegistry
   )
     @path_prefix = path_prefix
     @logger = logger
-    headers = {
+    headers = Excon.defaults[:headers].merge(
       "Content-Type" => CONTENT_TYPE
-    }
+    )
     headers[:proxy] = proxy unless proxy.nil?
     @connection = Excon.new(
       url,

--- a/spec/support/confluent_schema_registry_context.rb
+++ b/spec/support/confluent_schema_registry_context.rb
@@ -13,9 +13,20 @@ shared_examples_for "a confluent schema registry client" do
       ]
     }.to_json
   end
+  let(:headers) do
+    {
+      'Accept'=>'*/*',
+      'Content-Type'=> AvroTurf::ConfluentSchemaRegistry::CONTENT_TYPE,
+      'Host'=> "#{URI.parse(registry_url).host}:80",
+      'User-Agent'=> "excon/#{Excon::VERSION}"
+    }
+  end
 
   before do
-    stub_request(:any, /^#{registry_url}/).to_rack(FakeConfluentSchemaRegistryServer)
+    stub_request(:any, /^#{registry_url}/)
+      .with(headers: headers)
+      .to_rack(FakeConfluentSchemaRegistryServer)
+
     FakeConfluentSchemaRegistryServer.clear
   end
 


### PR DESCRIPTION
Use `Excon` default headers when sending requests to the schema registry, to add Accept and User-Agent.

Some companies (including mine) have some security policies that forbid requests from empty or blacklisted user agents, so AvroTurf requests are blocked since the current implementation replaces the Excon default headers with some new ones.

This PR just makes sure that the defaults are kept and merged with the new ones.