### PR TITLE
Fix AvroTurf::SchemaStore#load_schemas! depends on file order

### DIFF
--- a/lib/avro_turf/schema_store.rb
+++ b/lib/avro_turf/schema_store.rb
@@ -22,7 +22,7 @@ class AvroTurf::SchemaStore
       # Still need to check is the schema already loaded
       return @schemas[fullname] if @schemas.key?(fullname)
 
-      load_schema!(fullname)
+      load_schema!(fullname, @schemas.dup)
     end
   end
 

--- a/spec/schema_store_spec.rb
+++ b/spec/schema_store_spec.rb
@@ -361,6 +361,49 @@ describe AvroTurf::SchemaStore do
   end
 
   describe "#load_schemas!" do
+    it "do not try to reload known schemas" do
+      define_schema "first.avsc", <<-AVSC
+        {
+          "name": "first",
+          "type": "record",
+          "fields": [
+            {
+              "type": "string",
+              "name": "a_value"
+            }
+          ]
+        }
+      AVSC
+
+      define_schema "second.avsc", <<-AVSC
+        {
+          "name": "second",
+          "type": "record",
+          "fields": [
+            {
+              "type": "first",
+              "name": "full_name"
+            }
+          ]
+        }
+      AVSC
+
+      define_schema "third.avsc", <<-AVSC
+        {
+          "name": "third",
+          "type": "record",
+          "fields": [
+            {
+              "type": "second",
+              "name": "embedded_first"
+            }
+          ]
+        }
+      AVSC
+
+      expect { store.load_schemas! }.not_to raise_error
+    end
+
     it "loads schemas defined in the `schemas_path` directory" do
       define_schema "person.avsc", <<-AVSC
         {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'bundler/setup'
 require 'logger'
 require 'json_spec'
+require 'pp' # Require pp before fakefs to fix TypeError: superclass mismatch for class File
 require 'fakefs/spec_helpers'
 require 'avro_turf'
 


### PR DESCRIPTION
This happens because when loading schemas using `find`, the already loaded schemas are not provided to `load_schema!`. With Schema Z being required by schema X itself required by schema Y, and schemas being loaded in alphabetical order, when loading Y, local_schemas_cache is empty when `load_schema!(Y)` is called.
  This makes parsing the schema fails because X is unknown (to load_schema!, even if present in @schemas).
    An attempt is made to have X loaded, to `local_schemas_cache`
      This fails because Z is not in `local_schemas_cache`
        Z is loaded, and added to `local_schemas_cache`
        Then, a second attempt is made to load X, but providing @schemas, this time.
          Avro fails, because X is already loaded

This change basically provides @schemas.dup when `find` calls `load_schema!` to make sure X is found on first try.

Fixes #181