### PR TITLE
Add support for getting subject and version when given a schema id.

### DIFF
--- a/lib/avro_turf/cached_confluent_schema_registry.rb
+++ b/lib/avro_turf/cached_confluent_schema_registry.rb
@@ -17,7 +17,7 @@ class AvroTurf::CachedConfluentSchemaRegistry
   end
 
   # Delegate the following methods to the upstream
-  %i(subjects subject_versions check compatible?
+  %i(subjects subject_versions schema_subject_version check compatible?
      global_config update_global_config subject_config update_subject_config).each do |name|
     define_method(name) do |*args|
       instance_variable_get(:@upstream).send(name, *args)

--- a/lib/avro_turf/confluent_schema_registry.rb
+++ b/lib/avro_turf/confluent_schema_registry.rb
@@ -68,6 +68,11 @@ class AvroTurf::ConfluentSchemaRegistry
     get("/subjects/#{subject}/versions/#{version}")
   end
 
+  # Get the subject and version for a schema id
+  def schema_subject_version(schema_id)
+    get("/schemas/ids/#{schema_id}/versions")[0]
+  end
+
   # Check if a schema exists. Returns nil if not found.
   def check(subject, schema)
     data = post("/subjects/#{subject}",

--- a/lib/avro_turf/test/fake_confluent_schema_registry_server.rb
+++ b/lib/avro_turf/test/fake_confluent_schema_registry_server.rb
@@ -52,6 +52,20 @@ class FakeConfluentSchemaRegistryServer < Sinatra::Base
     { id: schema_id }.to_json
   end
 
+  get "/schemas/ids/:schema_id/versions" do
+    schema_id = params[:schema_id].to_i
+    schema = SCHEMAS.at(schema_id)
+    halt(404, SCHEMA_NOT_FOUND) unless schema
+
+    subject, schema_ids = SUBJECTS.find {|_, vs| vs.include? schema_id }
+    version = schema_ids.find_index(schema_id) + 1
+
+    [{
+       subject: subject,
+       version: version
+    }].to_json
+  end
+
   get "/schemas/ids/:schema_id" do
     schema = SCHEMAS.at(params[:schema_id].to_i)
     halt(404, SCHEMA_NOT_FOUND) unless schema

--- a/spec/support/confluent_schema_registry_context.rb
+++ b/spec/support/confluent_schema_registry_context.rb
@@ -77,6 +77,29 @@ shared_examples_for "a confluent schema registry client" do
     end
   end
 
+  describe "#schema_subject_version" do
+    it "returns subject and version for a schema id" do
+      schema_id1 = registry.register(subject_name, { type: :record, name: "r1", fields: [] }.to_json)
+      schema_id2 = registry.register(subject_name, { type: :record, name: "r2", fields: [] }.to_json)
+      expect(registry.schema_subject_version(schema_id1)).to eq({
+        'subject' => subject_name,
+        'version' => 1
+      })
+      expect(registry.schema_subject_version(schema_id2)).to eq({
+        'subject' => subject_name,
+        'version' => 2
+      })
+    end
+
+    context "when the schema does not exist" do
+      it "raises an error" do
+        expect do
+          registry.schema_subject_version(-1)
+        end.to raise_error(Excon::Errors::NotFound)
+      end
+    end
+  end
+
   describe "#subject_versions" do
     it "lists all the versions for the subject" do
       2.times do |n|

--- a/spec/test/fake_confluent_schema_registry_server_spec.rb
+++ b/spec/test/fake_confluent_schema_registry_server_spec.rb
@@ -37,4 +37,33 @@ describe FakeConfluentSchemaRegistryServer do
       expect(JSON.parse(last_response.body).fetch('id')).not_to eq original_id
     end
   end
+
+  describe 'GET /schemas/ids/:id/versions' do
+    let(:other_schema) do
+      {
+        type: "record",
+        name: "person",
+        fields: [
+          { name: "name", type: "string" },
+          { name: "age", type: "int" }
+        ]
+      }.to_json
+    end
+
+    it "returns array with one element containing subject and version for given schema id" do
+      subject = 'customer'
+      post "/subjects/#{subject}/versions", { schema: schema }.to_json, 'CONTENT_TYPE' => 'application/vnd.schemaregistry+json'
+      post "/subjects/#{subject}/versions", { schema: other_schema }.to_json, 'CONTENT_TYPE' => 'application/vnd.schemaregistry+json'
+      schema_id = JSON.parse(last_response.body).fetch('id')
+
+      get "/schemas/ids/#{schema_id}/versions"
+
+      result = JSON.parse(last_response.body)
+
+      expect(result).to eq [{
+        'subject' => subject,
+        'version' => 2
+      }]
+    end
+  end
 end


### PR DESCRIPTION
Getting /schemas/ids/#{schema_id}/versions returns information about subject and version

This PR adds support in AvroTurf::ConfluentSchemaRegistry