### PR TITLE
Same schema should give same id, even when the subject is different.

### DIFF
--- a/lib/avro_turf/test/fake_confluent_schema_registry_server.rb
+++ b/lib/avro_turf/test/fake_confluent_schema_registry_server.rb
@@ -35,18 +35,15 @@ class FakeConfluentSchemaRegistryServer < Sinatra::Base
 
   post "/subjects/:subject/versions" do
     schema = parse_schema
-    ids_for_subject = SUBJECTS[params[:subject]]
-
-    schemas_for_subject =
-      SCHEMAS.select
-             .with_index { |_, i| ids_for_subject.include?(i) }
-
-    if schemas_for_subject.include?(schema)
-      schema_id = SCHEMAS.index(schema)
-    else
+    schema_id = SCHEMAS.index(schema)
+    if schema_id.nil?
       SCHEMAS << schema
       schema_id = SCHEMAS.size - 1
-      SUBJECTS[params[:subject]] = SUBJECTS[params[:subject]] << schema_id
+    end
+
+    subject = params[:subject]
+    unless SUBJECTS[subject].include?(schema_id)
+      SUBJECTS[subject] = SUBJECTS[subject] << schema_id
     end
 
     { id: schema_id }.to_json

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -109,7 +109,7 @@ describe AvroTurf::Messaging do
     end
 
     it 'encodes and decodes messages' do
-      data = avro.encode(message, schema_id: 1)
+      data = avro.encode(message, schema_id: 0)
       expect(avro.decode(data)).to eq message
     end
 
@@ -118,7 +118,7 @@ describe AvroTurf::Messaging do
     end
 
     it 'caches parsed schemas for decoding' do
-      data = avro.encode(message, schema_id: 1)
+      data = avro.encode(message, schema_id: 0)
       avro.decode(data)
       allow(Avro::Schema).to receive(:parse).and_call_original
       expect(avro.decode(data)).to eq message

--- a/spec/test/fake_confluent_schema_registry_server_spec.rb
+++ b/spec/test/fake_confluent_schema_registry_server_spec.rb
@@ -27,14 +27,32 @@ describe FakeConfluentSchemaRegistryServer do
       expect(JSON.parse(last_response.body).fetch('id')).to eq expected_id
     end
 
-    it 'returns a different schema ID when invoked with same schema and different subject' do
+    it 'returns the same schema ID when invoked with same schema and different subject' do
       post '/subjects/person/versions', { schema: schema }.to_json, 'CONTENT_TYPE' => 'application/vnd.schemaregistry+json'
 
       original_id = JSON.parse(last_response.body).fetch('id')
 
       post '/subjects/happy-person/versions', { schema: schema }.to_json, 'CONTENT_TYPE' => 'application/vnd.schemaregistry+json'
 
-      expect(JSON.parse(last_response.body).fetch('id')).not_to eq original_id
+      expect(JSON.parse(last_response.body).fetch('id')).to eq original_id
+    end
+
+    it 'returns a different schema ID when invoked with a different schema' do
+      post '/subjects/person/versions', { schema: schema }.to_json, 'CONTENT_TYPE' => 'application/vnd.schemaregistry+json'
+
+      original_id = JSON.parse(last_response.body).fetch('id')
+
+      other_schema = {
+        type: "record",
+        name: "other",
+        fields: [
+          { name: "name", type: "string" }
+        ]
+      }.to_json
+
+      post '/subjects/person/versions', { schema: other_schema }.to_json, 'CONTENT_TYPE' => 'application/vnd.schemaregistry+json'
+
+      expect(JSON.parse(last_response.body).fetch('id')).to_not eq original_id
     end
   end
 end


### PR DESCRIPTION
Fixes behaviour of FakeConfluentSchemaRegistryServer - same schema for different subject should return same schema id. See [Schema Registry API Reference](https://docs.confluent.io/platform/current/schema-registry/develop/api.html#:~:text=If%20the%20same%20schema%20is%20registered%20under%20a%20different%20subject%2C%20the%20same%20identifier%20will%20be%20returned.%20However%2C%20the%20version%20of%20the%20schema%20may%20be%20different%20under%20different%20subjects.) which states 

```If the same schema is registered under a different subject, the same identifier will be returned. However, the version of the schema may be different under different subjects.```
