### PR TITLE
Schema subject versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `schema_subject_versions` to `ConfluentSchemaRegistry` to retrieve all subject versions for a schema id. (#189)
+- `FakeConfluentSchemaRegistryServer` now returns same id if identical schema is created for a different subject (#188)
+
 ## v1.9.0
 
 - Send Accept and User-Agent headers on every request (#184)

--- a/lib/avro_turf/cached_confluent_schema_registry.rb
+++ b/lib/avro_turf/cached_confluent_schema_registry.rb
@@ -17,7 +17,7 @@ class AvroTurf::CachedConfluentSchemaRegistry
   end
 
   # Delegate the following methods to the upstream
-  %i(subjects subject_versions check compatible?
+  %i(subjects subject_versions schema_subject_version check compatible?
      global_config update_global_config subject_config update_subject_config).each do |name|
     define_method(name) do |*args|
       instance_variable_get(:@upstream).send(name, *args)

--- a/lib/avro_turf/cached_confluent_schema_registry.rb
+++ b/lib/avro_turf/cached_confluent_schema_registry.rb
@@ -17,7 +17,7 @@ class AvroTurf::CachedConfluentSchemaRegistry
   end
 
   # Delegate the following methods to the upstream
-  %i(subjects subject_versions schema_subject_version check compatible?
+  %i(subjects subject_versions schema_subject_versions check compatible?
      global_config update_global_config subject_config update_subject_config).each do |name|
     define_method(name) do |*args|
       instance_variable_get(:@upstream).send(name, *args)

--- a/lib/avro_turf/confluent_schema_registry.rb
+++ b/lib/avro_turf/confluent_schema_registry.rb
@@ -69,7 +69,7 @@ class AvroTurf::ConfluentSchemaRegistry
   end
 
   # Get the subject and version for a schema id
-  def schema_subject_version(schema_id)
+  def schema_subject_versions(schema_id)
     get("/schemas/ids/#{schema_id}/versions")
   end
 

--- a/lib/avro_turf/confluent_schema_registry.rb
+++ b/lib/avro_turf/confluent_schema_registry.rb
@@ -68,6 +68,11 @@ class AvroTurf::ConfluentSchemaRegistry
     get("/subjects/#{subject}/versions/#{version}")
   end
 
+  # Get the subject and version for a schema id
+  def schema_subject_version(schema_id)
+    get("/schemas/ids/#{schema_id}/versions")
+  end
+
   # Check if a schema exists. Returns nil if not found.
   def check(subject, schema)
     data = post("/subjects/#{subject}",

--- a/lib/avro_turf/test/fake_confluent_schema_registry_server.rb
+++ b/lib/avro_turf/test/fake_confluent_schema_registry_server.rb
@@ -49,6 +49,21 @@ class FakeConfluentSchemaRegistryServer < Sinatra::Base
     { id: schema_id }.to_json
   end
 
+  get "/schemas/ids/:schema_id/versions" do
+    schema_id = params[:schema_id].to_i
+    schema = SCHEMAS.at(schema_id)
+    halt(404, SCHEMA_NOT_FOUND) unless schema
+
+    related_subjects = SUBJECTS.select {|_, vs| vs.include? schema_id }
+
+    related_subjects.map do |subject, versions|
+      {
+        subject: subject,
+        version: versions.find_index(schema_id) + 1
+      }
+    end.to_json
+  end
+
   get "/schemas/ids/:schema_id" do
     schema = SCHEMAS.at(params[:schema_id].to_i)
     halt(404, SCHEMA_NOT_FOUND) unless schema

--- a/spec/support/confluent_schema_registry_context.rb
+++ b/spec/support/confluent_schema_registry_context.rb
@@ -77,16 +77,16 @@ shared_examples_for "a confluent schema registry client" do
     end
   end
 
-  describe "#schema_subject_version" do
+  describe "#schema_subject_versions" do
     it "returns subject and version for a schema id" do
       schema_id1 = registry.register(subject_name, { type: :record, name: "r1", fields: [] }.to_json)
       registry.register(subject_name, { type: :record, name: "r2", fields: [] }.to_json)
       schema_id2 = registry.register("other#{subject_name}", { type: :record, name: "r2", fields: [] }.to_json)
-      expect(registry.schema_subject_version(schema_id1)).to eq([
+      expect(registry.schema_subject_versions(schema_id1)).to eq([
         'subject' => subject_name,
         'version' => 1
       ])
-      expect(registry.schema_subject_version(schema_id2)).to include({
+      expect(registry.schema_subject_versions(schema_id2)).to include({
         'subject' => subject_name,
         'version' => 2
       },{
@@ -98,7 +98,7 @@ shared_examples_for "a confluent schema registry client" do
     context "when the schema does not exist" do
       it "raises an error" do
         expect do
-          registry.schema_subject_version(-1)
+          registry.schema_subject_versions(-1)
         end.to raise_error(Excon::Errors::NotFound)
       end
     end

--- a/spec/support/confluent_schema_registry_context.rb
+++ b/spec/support/confluent_schema_registry_context.rb
@@ -77,6 +77,33 @@ shared_examples_for "a confluent schema registry client" do
     end
   end
 
+  describe "#schema_subject_version" do
+    it "returns subject and version for a schema id" do
+      schema_id1 = registry.register(subject_name, { type: :record, name: "r1", fields: [] }.to_json)
+      registry.register(subject_name, { type: :record, name: "r2", fields: [] }.to_json)
+      schema_id2 = registry.register("other#{subject_name}", { type: :record, name: "r2", fields: [] }.to_json)
+      expect(registry.schema_subject_version(schema_id1)).to eq([
+        'subject' => subject_name,
+        'version' => 1
+      ])
+      expect(registry.schema_subject_version(schema_id2)).to include({
+        'subject' => subject_name,
+        'version' => 2
+      },{
+        'subject' => "other#{subject_name}",
+        'version' => 1
+      } )
+    end
+
+    context "when the schema does not exist" do
+      it "raises an error" do
+        expect do
+          registry.schema_subject_version(-1)
+        end.to raise_error(Excon::Errors::NotFound)
+      end
+    end
+  end
+
   describe "#subject_versions" do
     it "lists all the versions for the subject" do
       2.times do |n|


### PR DESCRIPTION
Confluent schema registry has an api to [get the subject-version pairs identified by the input schema id](https://docs.confluent.io/platform/current/schema-registry/develop/api.html#get--schemas-ids-int-%20id-versions). This PR add support to AvroTurf::ConfluentSchemaRegistry.

NOTE: To be able to write the test for this functionality is was necessary to assume the previous PR relating to schema ids for identical schemas was fixed, so this PR is based on that branch.