### PR TITLE
Add `decode_all` and `decode_all_from_stream` methods to return all 'entries'

### DIFF
--- a/lib/avro_turf.rb
+++ b/lib/avro_turf.rb
@@ -98,6 +98,12 @@ class AvroTurf
     decode_stream(stream, schema_name: schema_name, namespace: namespace)
   end
 
+  # Returns all entries encoded in the data.
+  def decode_all(encoded_data, schema_name: nil, namespace: @namespace)
+    stream = StringIO.new(encoded_data)
+    decode_all_from_stream(stream, schema_name: schema_name, namespace: namespace)
+  end
+
   # Decodes Avro data from an IO stream.
   #
   # stream       - An IO object containing Avro data.
@@ -105,12 +111,20 @@ class AvroTurf
   #                the data. If nil, the writer schema will be used.
   # namespace    - The namespace of the Avro schema used to decode the data.
   #
-  # Returns whatever is encoded in the stream.
+  # Returns first entry encoded in the stream.
   def decode_stream(stream, schema_name: nil, namespace: @namespace)
     schema = schema_name && @schema_store.find(schema_name, namespace)
     reader = Avro::IO::DatumReader.new(nil, schema)
     dr = Avro::DataFile::Reader.new(stream, reader)
     dr.first
+  end
+
+  # Returns all entries encoded in the stream.
+  def decode_all_from_stream(stream, schema_name: nil, namespace: @namespace)
+    schema = schema_name && @schema_store.find(schema_name, namespace)
+    reader = Avro::IO::DatumReader.new(nil, schema)
+    dr = Avro::DataFile::Reader.new(stream, reader)
+    dr.entries
   end
 
   # Validates data against an Avro schema.

--- a/lib/avro_turf.rb
+++ b/lib/avro_turf.rb
@@ -109,8 +109,12 @@ class AvroTurf
   def decode_stream(stream, schema_name: nil, namespace: @namespace)
     schema = schema_name && @schema_store.find(schema_name, namespace)
     reader = Avro::IO::DatumReader.new(nil, schema)
-    dr = Avro::DataFile::Reader.new(stream, reader)
-    dr.first
+    entries = Avro::DataFile::Reader.new(stream, reader).entries
+
+    case entries.size
+    when 1 then entries.first
+    when 2.. then entries
+    end
   end
 
   # Validates data against an Avro schema.

--- a/lib/avro_turf.rb
+++ b/lib/avro_turf.rb
@@ -109,12 +109,8 @@ class AvroTurf
   def decode_stream(stream, schema_name: nil, namespace: @namespace)
     schema = schema_name && @schema_store.find(schema_name, namespace)
     reader = Avro::IO::DatumReader.new(nil, schema)
-    entries = Avro::DataFile::Reader.new(stream, reader).entries
-
-    case entries.size
-    when 1 then entries.first
-    when 2.. then entries
-    end
+    dr = Avro::DataFile::Reader.new(stream, reader)
+    dr.first
   end
 
   # Validates data against an Avro schema.

--- a/spec/avro_turf_spec.rb
+++ b/spec/avro_turf_spec.rb
@@ -142,7 +142,7 @@ describe AvroTurf do
   end
 
   describe "#decode" do
-    it "returns an entry when decodes Avro data containing only one entry using the inlined writer's schema" do
+    it "decodes Avro data using the inlined writer's schema" do
       define_schema "message.avsc", <<-AVSC
         {
           "name": "message",
@@ -153,18 +153,6 @@ describe AvroTurf do
       encoded_data = avro.encode("hello, world", schema_name: "message")
 
       expect(avro.decode(encoded_data)).to eq "hello, world"
-    end
-
-    it "returns array of entries using the inlined writer's schema when data contains multiple entries" do
-      encoded_data = "Obj\u0001\u0004\u0014avro.codec\bnull\u0016avro.schema\xB6\u0004[{\"type\": \"record\", \"name\": \"address\", \"fields\": [{\"type\": \"string\", \"name\": \"street\"}, {\"type\": \"string\", \"name\": \"city\"}]}, {\"type\": \"record\", \"name\": \"person\", \"fields\": [{\"type\": \"string\", \"name\": \"name\"}, {\"type\": \"int\", \"name\": \"age\"}, {\"type\": \"address\", \"name\": \"address\"}]}]\u0000\xF9u\x84\xA1c\u0010\x82B\xE2\xCF\xF1\x98\xF7\xF1JH\u0004\x96\u0001\u0002\u0014Python🐍\x80\u0004\u0018Green Street\u001ASan Francisco\u0002\u0010Mojo🐍\u0002\u0016Blue Street\u0014Saturn🪐\xF9u\x84\xA1c\u0010\x82B\xE2\xCF\xF1\x98\xF7\xF1JH"
-
-      expect(avro.decode(encoded_data)).to eq(
-        [
-          {"name"=>"Python🐍", "age"=>256, "address"=>{"street"=>"Green Street", "city"=>"San Francisco"}},
-          {"name"=>"Mojo🐍", "age"=>1, "address"=>{"street"=>"Blue Street", "city"=>"Saturn🪐"}}
-        ]
-      )
-
     end
 
     it "decodes Avro data using a specified reader's schema" do
@@ -301,7 +289,7 @@ describe AvroTurf do
   end
 
   describe "#decode_stream" do
-    it "returns an entry when decodes Avro data from a stream containing only one entry" do
+    it "decodes Avro data from a stream" do
       define_schema "message.avsc", <<-AVSC
         {
           "name": "message",
@@ -313,18 +301,6 @@ describe AvroTurf do
       stream = StringIO.new(encoded_data)
 
       expect(avro.decode_stream(stream)).to eq "hello"
-    end
-
-    it "returns all entries when decodes Avro data from a stream containing multiple entries" do
-      encoded_data = "Obj\u0001\u0004\u0014avro.codec\bnull\u0016avro.schema\xB6\u0004[{\"type\": \"record\", \"name\": \"address\", \"fields\": [{\"type\": \"string\", \"name\": \"street\"}, {\"type\": \"string\", \"name\": \"city\"}]}, {\"type\": \"record\", \"name\": \"person\", \"fields\": [{\"type\": \"string\", \"name\": \"name\"}, {\"type\": \"int\", \"name\": \"age\"}, {\"type\": \"address\", \"name\": \"address\"}]}]\u0000\xF9u\x84\xA1c\u0010\x82B\xE2\xCF\xF1\x98\xF7\xF1JH\u0004\x96\u0001\u0002\u0014Python🐍\x80\u0004\u0018Green Street\u001ASan Francisco\u0002\u0010Mojo🐍\u0002\u0016Blue Street\u0014Saturn🪐\xF9u\x84\xA1c\u0010\x82B\xE2\xCF\xF1\x98\xF7\xF1JH"
-      stream = StringIO.new(encoded_data)
-
-      expect(avro.decode_stream(stream)).to eq(
-        [
-          {"name"=>"Python🐍", "age"=>256, "address"=>{"street"=>"Green Street", "city"=>"San Francisco"}},
-          {"name"=>"Mojo🐍", "age"=>1, "address"=>{"street"=>"Blue Street", "city"=>"Saturn🪐"}}
-        ]
-      )
     end
   end
 

--- a/spec/avro_turf_spec.rb
+++ b/spec/avro_turf_spec.rb
@@ -142,7 +142,7 @@ describe AvroTurf do
   end
 
   describe "#decode" do
-    it "decodes Avro data using the inlined writer's schema" do
+    it "returns an entry when decodes Avro data containing only one entry using the inlined writer's schema" do
       define_schema "message.avsc", <<-AVSC
         {
           "name": "message",
@@ -153,6 +153,18 @@ describe AvroTurf do
       encoded_data = avro.encode("hello, world", schema_name: "message")
 
       expect(avro.decode(encoded_data)).to eq "hello, world"
+    end
+
+    it "returns array of entries using the inlined writer's schema when data contains multiple entries" do
+      encoded_data = "Obj\u0001\u0004\u0014avro.codec\bnull\u0016avro.schema\xB6\u0004[{\"type\": \"record\", \"name\": \"address\", \"fields\": [{\"type\": \"string\", \"name\": \"street\"}, {\"type\": \"string\", \"name\": \"city\"}]}, {\"type\": \"record\", \"name\": \"person\", \"fields\": [{\"type\": \"string\", \"name\": \"name\"}, {\"type\": \"int\", \"name\": \"age\"}, {\"type\": \"address\", \"name\": \"address\"}]}]\u0000\xF9u\x84\xA1c\u0010\x82B\xE2\xCF\xF1\x98\xF7\xF1JH\u0004\x96\u0001\u0002\u0014Python🐍\x80\u0004\u0018Green Street\u001ASan Francisco\u0002\u0010Mojo🐍\u0002\u0016Blue Street\u0014Saturn🪐\xF9u\x84\xA1c\u0010\x82B\xE2\xCF\xF1\x98\xF7\xF1JH"
+
+      expect(avro.decode(encoded_data)).to eq(
+        [
+          {"name"=>"Python🐍", "age"=>256, "address"=>{"street"=>"Green Street", "city"=>"San Francisco"}},
+          {"name"=>"Mojo🐍", "age"=>1, "address"=>{"street"=>"Blue Street", "city"=>"Saturn🪐"}}
+        ]
+      )
+
     end
 
     it "decodes Avro data using a specified reader's schema" do
@@ -289,7 +301,7 @@ describe AvroTurf do
   end
 
   describe "#decode_stream" do
-    it "decodes Avro data from a stream" do
+    it "returns an entry when decodes Avro data from a stream containing only one entry" do
       define_schema "message.avsc", <<-AVSC
         {
           "name": "message",
@@ -301,6 +313,18 @@ describe AvroTurf do
       stream = StringIO.new(encoded_data)
 
       expect(avro.decode_stream(stream)).to eq "hello"
+    end
+
+    it "returns all entries when decodes Avro data from a stream containing multiple entries" do
+      encoded_data = "Obj\u0001\u0004\u0014avro.codec\bnull\u0016avro.schema\xB6\u0004[{\"type\": \"record\", \"name\": \"address\", \"fields\": [{\"type\": \"string\", \"name\": \"street\"}, {\"type\": \"string\", \"name\": \"city\"}]}, {\"type\": \"record\", \"name\": \"person\", \"fields\": [{\"type\": \"string\", \"name\": \"name\"}, {\"type\": \"int\", \"name\": \"age\"}, {\"type\": \"address\", \"name\": \"address\"}]}]\u0000\xF9u\x84\xA1c\u0010\x82B\xE2\xCF\xF1\x98\xF7\xF1JH\u0004\x96\u0001\u0002\u0014Python🐍\x80\u0004\u0018Green Street\u001ASan Francisco\u0002\u0010Mojo🐍\u0002\u0016Blue Street\u0014Saturn🪐\xF9u\x84\xA1c\u0010\x82B\xE2\xCF\xF1\x98\xF7\xF1JH"
+      stream = StringIO.new(encoded_data)
+
+      expect(avro.decode_stream(stream)).to eq(
+        [
+          {"name"=>"Python🐍", "age"=>256, "address"=>{"street"=>"Green Street", "city"=>"San Francisco"}},
+          {"name"=>"Mojo🐍", "age"=>1, "address"=>{"street"=>"Blue Street", "city"=>"Saturn🪐"}}
+        ]
+      )
     end
   end
 


### PR DESCRIPTION
 `decode` and `decode_stream` methods does not return all entries, but rather a first entry.

This was noticed when decoding Avro data encoded using different libraries as per discussion:
https://github.com/dasch/avro_turf/discussions/193

I believe the same functionality might be needed for `encode` path.