### PR TITLE
Avoid bringing entries into memory

### DIFF
--- a/lib/avro_turf.rb
+++ b/lib/avro_turf.rb
@@ -104,7 +104,7 @@ class AvroTurf
     decode_all_from_stream(stream, schema_name: schema_name, namespace: namespace)
   end
 
-  # Decodes Avro data from an IO stream.
+  # Decodes the first entry from an IO stream containing Avro data.
   #
   # stream       - An IO object containing Avro data.
   # schema_name  - The String name of the schema that should be used to read
@@ -113,10 +113,8 @@ class AvroTurf
   #
   # Returns first entry encoded in the stream.
   def decode_stream(stream, schema_name: nil, namespace: @namespace)
-    schema = schema_name && @schema_store.find(schema_name, namespace)
-    reader = Avro::IO::DatumReader.new(nil, schema)
-    dr = Avro::DataFile::Reader.new(stream, reader)
-    dr.first
+    data = decode_all_from_stream(stream, schema_name: schema_name, namespace: namespace)
+    data.first
   end
 
   # Returns all entries encoded in the stream.

--- a/lib/avro_turf.rb
+++ b/lib/avro_turf.rb
@@ -123,8 +123,7 @@ class AvroTurf
   def decode_all_from_stream(stream, schema_name: nil, namespace: @namespace)
     schema = schema_name && @schema_store.find(schema_name, namespace)
     reader = Avro::IO::DatumReader.new(nil, schema)
-    dr = Avro::DataFile::Reader.new(stream, reader)
-    dr.entries
+    Avro::DataFile::Reader.new(stream, reader)
   end
 
   # Validates data against an Avro schema.

--- a/lib/avro_turf.rb
+++ b/lib/avro_turf.rb
@@ -93,10 +93,12 @@ class AvroTurf
   # namespace    - The namespace of the Avro schema used to decode the data.
   #
   # Returns whatever is encoded in the data.
-  def decode(encoded_data, schema_name: nil, namespace: @namespace)
+  def decode_first(encoded_data, schema_name: nil, namespace: @namespace)
     stream = StringIO.new(encoded_data)
     decode_stream(stream, schema_name: schema_name, namespace: namespace)
   end
+
+  alias decode decode_first
 
   # Returns all entries encoded in the data.
   def decode_all(encoded_data, schema_name: nil, namespace: @namespace)
@@ -112,10 +114,12 @@ class AvroTurf
   # namespace    - The namespace of the Avro schema used to decode the data.
   #
   # Returns first entry encoded in the stream.
-  def decode_stream(stream, schema_name: nil, namespace: @namespace)
+  def decode_first_from_stream(stream, schema_name: nil, namespace: @namespace)
     data = decode_all_from_stream(stream, schema_name: schema_name, namespace: namespace)
     data.first
   end
+
+  alias decode_stream decode_first_from_stream
 
   # Returns all entries encoded in the stream.
   def decode_all_from_stream(stream, schema_name: nil, namespace: @namespace)

--- a/spec/avro_turf_spec.rb
+++ b/spec/avro_turf_spec.rb
@@ -191,7 +191,7 @@ describe AvroTurf do
       let(:encoded_data) {  "Obj\u0001\u0004\u0014avro.codec\bnull\u0016avro.schema\xB6\u0004[{\"type\": \"record\", \"name\": \"address\", \"fields\": [{\"type\": \"string\", \"name\": \"street\"}, {\"type\": \"string\", \"name\": \"city\"}]}, {\"type\": \"record\", \"name\": \"person\", \"fields\": [{\"type\": \"string\", \"name\": \"name\"}, {\"type\": \"int\", \"name\": \"age\"}, {\"type\": \"address\", \"name\": \"address\"}]}]\u0000\xF9u\x84\xA1c\u0010\x82B\xE2\xCF\xF1\x98\xF7\xF1JH\u0004\x96\u0001\u0002\u0014Python🐍\x80\u0004\u0018Green Street\u001ASan Francisco\u0002\u0010Mojo🐍\u0002\u0016Blue Street\u0014Saturn🪐\xF9u\x84\xA1c\u0010\x82B\xE2\xCF\xF1\x98\xF7\xF1JH" } 
 
       it "returns array of entries decoded using the inlined writer's schema " do
-        expect(avro.decode_all(encoded_data)).to eq(
+        expect(avro.decode_all(encoded_data).entries).to eq(
           [
             {"name"=>"Python🐍", "age"=>256, "address"=>{"street"=>"Green Street", "city"=>"San Francisco"}},
             {"name"=>"Mojo🐍", "age"=>1, "address"=>{"street"=>"Blue Street", "city"=>"Saturn🪐"}}
@@ -216,7 +216,7 @@ describe AvroTurf do
 
         expect(
           AvroTurf.new(schemas_path: "spec/schemas/reader")
-                  .decode_all(encoded_data, schema_name: "person")
+                  .decode_all(encoded_data, schema_name: "person").entries
         ).to eq(
           [
             {"name"=>"Python🐍", "age"=>256, "fav_color"=>"red🟥"},
@@ -350,7 +350,7 @@ describe AvroTurf do
       encoded_data = "Obj\u0001\u0004\u0014avro.codec\bnull\u0016avro.schema\xB6\u0004[{\"type\": \"record\", \"name\": \"address\", \"fields\": [{\"type\": \"string\", \"name\": \"street\"}, {\"type\": \"string\", \"name\": \"city\"}]}, {\"type\": \"record\", \"name\": \"person\", \"fields\": [{\"type\": \"string\", \"name\": \"name\"}, {\"type\": \"int\", \"name\": \"age\"}, {\"type\": \"address\", \"name\": \"address\"}]}]\u0000\xF9u\x84\xA1c\u0010\x82B\xE2\xCF\xF1\x98\xF7\xF1JH\u0004\x96\u0001\u0002\u0014Python🐍\x80\u0004\u0018Green Street\u001ASan Francisco\u0002\u0010Mojo🐍\u0002\u0016Blue Street\u0014Saturn🪐\xF9u\x84\xA1c\u0010\x82B\xE2\xCF\xF1\x98\xF7\xF1JH"
       stream = StringIO.new(encoded_data)
 
-      expect(avro.decode_all_from_stream(stream)).to eq(
+      expect(avro.decode_all_from_stream(stream).entries).to eq(
         [
           {"name"=>"Python🐍", "age"=>256, "address"=>{"street"=>"Green Street", "city"=>"San Francisco"}},
           {"name"=>"Mojo🐍", "age"=>1, "address"=>{"street"=>"Blue Street", "city"=>"Saturn🪐"}}


### PR DESCRIPTION
Pass the `Reader` instance to the caller instead of turning the entries into an Array with `#entries`. This should allow for lazily consuming very large data files without running out of memory.