### PR TITLE
Add the connection options to the Messaging interface

### DIFF
--- a/lib/avro_turf/cached_confluent_schema_registry.rb
+++ b/lib/avro_turf/cached_confluent_schema_registry.rb
@@ -32,10 +32,10 @@ class AvroTurf::CachedConfluentSchemaRegistry
     @cache.lookup_by_schema(subject, schema) || @cache.store_by_schema(subject, schema, @upstream.register(subject, schema))
   end
 
-  def subject_version(subject, version = 'latest')
-    return @upstream.subject_version(subject, version) if version == 'latest'
+  def subject_version(subject, version = 'latest', **connection_options)
+    return @upstream.subject_version(subject, version, **connection_options) if version == 'latest'
 
     @cache.lookup_by_version(subject, version) ||
-      @cache.store_by_version(subject, version, @upstream.subject_version(subject, version))
+      @cache.store_by_version(subject, version, @upstream.subject_version(subject, version, **connection_options))
   end
 end

--- a/lib/avro_turf/cached_confluent_schema_registry.rb
+++ b/lib/avro_turf/cached_confluent_schema_registry.rb
@@ -24,8 +24,8 @@ class AvroTurf::CachedConfluentSchemaRegistry
     end
   end
 
-  def fetch(id)
-    @cache.lookup_by_id(id) || @cache.store_by_id(id, @upstream.fetch(id))
+  def fetch(id, **connection_options)
+    @cache.lookup_by_id(id) || @cache.store_by_id(id, @upstream.fetch(id, **connection_options))
   end
 
   def register(subject, schema)

--- a/lib/avro_turf/cached_confluent_schema_registry.rb
+++ b/lib/avro_turf/cached_confluent_schema_registry.rb
@@ -28,8 +28,8 @@ class AvroTurf::CachedConfluentSchemaRegistry
     @cache.lookup_by_id(id) || @cache.store_by_id(id, @upstream.fetch(id, **connection_options))
   end
 
-  def register(subject, schema)
-    @cache.lookup_by_schema(subject, schema) || @cache.store_by_schema(subject, schema, @upstream.register(subject, schema))
+  def register(subject, schema, **connection_options)
+    @cache.lookup_by_schema(subject, schema) || @cache.store_by_schema(subject, schema, @upstream.register(subject, schema, **connection_options))
   end
 
   def subject_version(subject, version = 'latest', **connection_options)

--- a/lib/avro_turf/confluent_schema_registry.rb
+++ b/lib/avro_turf/confluent_schema_registry.rb
@@ -43,8 +43,8 @@ class AvroTurf::ConfluentSchemaRegistry
     data.fetch("schema")
   end
 
-  def register(subject, schema)
-    data = post("/subjects/#{subject}/versions", body: { schema: schema.to_s }.to_json)
+  def register(subject, schema, **connection_options)
+    data = post("/subjects/#{subject}/versions", body: { schema: schema.to_s }.to_json, **connection_options)
 
     id = data.fetch("id")
 

--- a/lib/avro_turf/confluent_schema_registry.rb
+++ b/lib/avro_turf/confluent_schema_registry.rb
@@ -37,9 +37,9 @@ class AvroTurf::ConfluentSchemaRegistry
     )
   end
 
-  def fetch(id)
+  def fetch(id, **connection_options)
     @logger.info "Fetching schema with id #{id}"
-    data = get("/schemas/ids/#{id}")
+    data = get("/schemas/ids/#{id}", **connection_options)
     data.fetch("schema")
   end
 

--- a/lib/avro_turf/confluent_schema_registry.rb
+++ b/lib/avro_turf/confluent_schema_registry.rb
@@ -64,8 +64,8 @@ class AvroTurf::ConfluentSchemaRegistry
   end
 
   # Get a specific version for a subject
-  def subject_version(subject, version = 'latest')
-    get("/subjects/#{subject}/versions/#{version}")
+  def subject_version(subject, version = 'latest', **connection_options)
+    get("/subjects/#{subject}/versions/#{version}", **connection_options)
   end
 
   # Get the subject and version for a schema id

--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -97,31 +97,33 @@ class AvroTurf
 
     # Encodes a message using the specified schema.
     #
-    # message      - The message that should be encoded. Must be compatible with
-    #                the schema.
-    # schema_name  - The String name of the schema that should be used to encode
-    #                the data.
-    # namespace    - The namespace of the schema (optional).
-    # subject      - The subject name the schema should be registered under in
-    #                the schema registry (optional).
-    # version      - The integer version of the schema that should be used to decode
-    #                the data. Must match the schema used when encoding (optional).
-    # schema_id    - The integer id of the schema that should be used to encode
-    #                the data.
-    # validate     - The boolean for performing complete message validation before
-    #                encoding it, Avro::SchemaValidator::ValidationError with
-    #                a descriptive message will be raised in case of invalid message.
-    # read_timeout - The timeout for the connection to the schema registry. Defaults
-    #                to 60 seconds by Excon.
+    # message       - The message that should be encoded. Must be compatible with
+    #                 the schema.
+    # schema_name   - The String name of the schema that should be used to encode
+    #                 the data.
+    # namespace     - The namespace of the schema (optional).
+    # subject       - The subject name the schema should be registered under in
+    #                 the schema registry (optional).
+    # version       - The integer version of the schema that should be used to decode
+    #                 the data. Must match the schema used when encoding (optional).
+    # schema_id     - The integer id of the schema that should be used to encode
+    #                 the data.
+    # validate      - The boolean for performing complete message validation before
+    #                 encoding it, Avro::SchemaValidator::ValidationError with
+    #                 a descriptive message will be raised in case of invalid message.
+    # read_timeout  - The read timeout for the connection to the schema registry.
+    #                 Defaults to 60 seconds by Excon.
+    # write_timeout - The write timeout for the connection to the schema registry.
+    #                 Defaults to 60 seconds by Excon.
     #
     # Returns the encoded data as a String.
-    def encode(message, schema_name: nil, namespace: @namespace, subject: nil, version: nil, schema_id: nil, validate: false, read_timeout: nil)
+    def encode(message, schema_name: nil, namespace: @namespace, subject: nil, version: nil, schema_id: nil, validate: false, read_timeout: nil, write_timeout: nil)
       schema, schema_id = if schema_id
         fetch_schema_by_id(schema_id, read_timeout: read_timeout)
       elsif subject && version
         fetch_schema(subject: subject, version: version, read_timeout: read_timeout)
       elsif schema_name
-        register_schema(subject: subject, schema_name: schema_name, namespace: namespace, read_timeout: read_timeout)
+        register_schema(subject: subject, schema_name: schema_name, namespace: namespace, write_timeout: write_timeout)
       else
         raise ArgumentError.new('Neither schema_name nor schema_id nor subject + version provided to determine the schema.')
       end

--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -117,7 +117,7 @@ class AvroTurf
     # Returns the encoded data as a String.
     def encode(message, schema_name: nil, namespace: @namespace, subject: nil, version: nil, schema_id: nil, validate: false, read_timeout: nil)
       schema, schema_id = if schema_id
-        fetch_schema_by_id(schema_id)
+        fetch_schema_by_id(schema_id, read_timeout: read_timeout)
       elsif subject && version
         fetch_schema(subject: subject, version: version, read_timeout: read_timeout)
       elsif schema_name
@@ -213,9 +213,9 @@ class AvroTurf
     end
 
     # Fetch the schema from registry with the provided schema_id.
-    def fetch_schema_by_id(schema_id)
+    def fetch_schema_by_id(schema_id, **connection_options)
       schema = @schemas_by_id.fetch(schema_id) do
-        schema_json = @registry.fetch(schema_id)
+        schema_json = @registry.fetch(schema_id, **connection_options)
         Avro::Schema.parse(schema_json)
       end
       [schema, schema_id]

--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -121,7 +121,7 @@ class AvroTurf
       elsif subject && version
         fetch_schema(subject: subject, version: version, read_timeout: read_timeout)
       elsif schema_name
-        register_schema(subject: subject, schema_name: schema_name, namespace: namespace)
+        register_schema(subject: subject, schema_name: schema_name, namespace: namespace, read_timeout: read_timeout)
       else
         raise ArgumentError.new('Neither schema_name nor schema_id nor subject + version provided to determine the schema.')
       end
@@ -223,9 +223,9 @@ class AvroTurf
 
     # Schemas are registered under the full name of the top level Avro record
     # type, or `subject` if it's provided.
-    def register_schema(schema_name:, subject: nil, namespace: nil)
+    def register_schema(schema_name:, subject: nil, namespace: nil, **connection_options)
       schema = @schema_store.find(schema_name, namespace)
-      schema_id = @registry.register(subject || schema.fullname, schema)
+      schema_id = @registry.register(subject || schema.fullname, schema, **connection_options)
       [schema, schema_id]
     end
   end

--- a/spec/cached_confluent_schema_registry_spec.rb
+++ b/spec/cached_confluent_schema_registry_spec.rb
@@ -39,6 +39,7 @@ describe AvroTurf::CachedConfluentSchemaRegistry do
   describe '#subject_version' do
     let(:subject_name) { 'a_subject' }
     let(:version) { 1 }
+    let(:connection_options) { { read_timeout: 10 } }
     let(:schema_with_meta) do
       {
         subject: subject_name,
@@ -49,9 +50,9 @@ describe AvroTurf::CachedConfluentSchemaRegistry do
     end
 
     it 'caches the result of subject_version' do
-      allow(upstream).to receive(:subject_version).with(subject_name, version).and_return(schema_with_meta)
-      registry.subject_version(subject_name, version)
-      registry.subject_version(subject_name, version)
+      allow(upstream).to receive(:subject_version).with(subject_name, version, **connection_options).and_return(schema_with_meta)
+      registry.subject_version(subject_name, version, **connection_options)
+      registry.subject_version(subject_name, version, **connection_options)
       expect(upstream).to have_received(:subject_version).exactly(1).times
     end
   end

--- a/spec/cached_confluent_schema_registry_spec.rb
+++ b/spec/cached_confluent_schema_registry_spec.rb
@@ -6,6 +6,7 @@ describe AvroTurf::CachedConfluentSchemaRegistry do
   let(:upstream) { instance_double(AvroTurf::ConfluentSchemaRegistry) }
   let(:registry) { described_class.new(upstream) }
   let(:id) { rand(999) }
+  let(:connection_options) { { read_timeout: 10 } }
   let(:schema) do
     {
       type: "record",
@@ -17,9 +18,9 @@ describe AvroTurf::CachedConfluentSchemaRegistry do
   describe "#fetch" do
     it "caches the result of fetch" do
       # multiple calls return same result, with only one upstream call
-      allow(upstream).to receive(:fetch).with(id).and_return(schema)
-      expect(registry.fetch(id)).to eq(schema)
-      expect(registry.fetch(id)).to eq(schema)
+      allow(upstream).to receive(:fetch).with(id, **connection_options).and_return(schema)
+      expect(registry.fetch(id, **connection_options)).to eq(schema)
+      expect(registry.fetch(id, **connection_options)).to eq(schema)
       expect(upstream).to have_received(:fetch).exactly(1).times
     end
   end
@@ -39,7 +40,6 @@ describe AvroTurf::CachedConfluentSchemaRegistry do
   describe '#subject_version' do
     let(:subject_name) { 'a_subject' }
     let(:version) { 1 }
-    let(:connection_options) { { read_timeout: 10 } }
     let(:schema_with_meta) do
       {
         subject: subject_name,

--- a/spec/cached_confluent_schema_registry_spec.rb
+++ b/spec/cached_confluent_schema_registry_spec.rb
@@ -30,9 +30,9 @@ describe AvroTurf::CachedConfluentSchemaRegistry do
 
     it "caches the result of register" do
       # multiple calls return same result, with only one upstream call
-      allow(upstream).to receive(:register).with(subject_name, schema).and_return(id)
-      expect(registry.register(subject_name, schema)).to eq(id)
-      expect(registry.register(subject_name, schema)).to eq(id)
+      allow(upstream).to receive(:register).with(subject_name, schema, **connection_options).and_return(id)
+      expect(registry.register(subject_name, schema, **connection_options)).to eq(id)
+      expect(registry.register(subject_name, schema, **connection_options)).to eq(id)
       expect(upstream).to have_received(:register).exactly(1).times
     end
   end

--- a/spec/cached_confluent_schema_registry_spec.rb
+++ b/spec/cached_confluent_schema_registry_spec.rb
@@ -6,7 +6,7 @@ describe AvroTurf::CachedConfluentSchemaRegistry do
   let(:upstream) { instance_double(AvroTurf::ConfluentSchemaRegistry) }
   let(:registry) { described_class.new(upstream) }
   let(:id) { rand(999) }
-  let(:connection_options) { { read_timeout: 10 } }
+  let(:connection_options) { { foo: :bar } }
   let(:schema) do
     {
       type: "record",

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -99,6 +99,11 @@ describe AvroTurf::Messaging do
       expect(avro.decode(data)).to eq message
       expect(Avro::Schema).not_to have_received(:parse)
     end
+
+    it 'passes the read_timeout connection option down to Excon' do
+      expect_any_instance_of(Excon::Connection).to receive(:request).with(hash_including(read_timeout: 10)).and_call_original
+      avro.encode(message, subject: 'person', version: 1, read_timeout: 10)
+    end
   end
 
   shared_examples_for 'encoding and decoding with the schema_id from registry' do

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -129,6 +129,11 @@ describe AvroTurf::Messaging do
       expect(avro.decode(data)).to eq message
       expect(Avro::Schema).not_to have_received(:parse)
     end
+
+    it 'passes the read_timeout connection option down to Excon' do
+      expect_any_instance_of(Excon::Connection).to receive(:request).with(hash_including(read_timeout: 10)).and_call_original
+      avro.encode(message, schema_id: 0, read_timeout: 10)
+    end
   end
 
   it_behaves_like "encoding and decoding with the schema from schema store"

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -163,14 +163,14 @@ describe AvroTurf::Messaging do
       allow(registry).to receive(:register).and_call_original
       message = { "full_name" => "John Doe" }
       avro.encode(message, schema_name: "person")
-      expect(registry).to have_received(:register).with("person", anything, { read_timeout: nil })
+      expect(registry).to have_received(:register).with("person", anything, { write_timeout: nil })
     end
 
     it "allows specifying a schema registry subject" do
       allow(registry).to receive(:register).and_call_original
       message = { "full_name" => "John Doe" }
       avro.encode(message, schema_name: "person", subject: "people")
-      expect(registry).to have_received(:register).with("people", anything, { read_timeout: nil })
+      expect(registry).to have_received(:register).with("people", anything, { write_timeout: nil })
     end
   end
 
@@ -277,14 +277,14 @@ describe AvroTurf::Messaging do
         allow(registry).to receive(:register).and_call_original
         message = { "full_name" => "John Doe" }
         avro.encode(message, schema_name: "person")
-        expect(registry).to have_received(:register).with("person", anything, { read_timeout: nil })
+        expect(registry).to have_received(:register).with("person", anything, { write_timeout: nil })
       end
 
       it "allows specifying a schema registry subject" do
         allow(registry).to receive(:register).and_call_original
         message = { "full_name" => "John Doe" }
         avro.encode(message, schema_name: "person", subject: "people")
-        expect(registry).to have_received(:register).with("people", anything, { read_timeout: nil })
+        expect(registry).to have_received(:register).with("people", anything, { write_timeout: nil })
       end
     end
 
@@ -384,10 +384,10 @@ describe AvroTurf::Messaging do
       end
 
       context 'when subject is not set' do
-        subject { avro.register_schema(schema_name: schema_name, namespace: namespace, read_timeout: 10) }
+        subject { avro.register_schema(schema_name: schema_name, namespace: namespace, write_timeout: 10) }
 
         before do
-          allow(registry).to receive(:register).with(schema.fullname, schema, { read_timeout: 10 }).and_return(schema_id)
+          allow(registry).to receive(:register).with(schema.fullname, schema, { write_timeout: 10 }).and_return(schema_id)
         end
 
         it 'registers schema in registry' do
@@ -396,12 +396,12 @@ describe AvroTurf::Messaging do
       end
 
       context 'when subject is set' do
-        subject { avro.register_schema(schema_name: schema_name, namespace: namespace, subject: subj, read_timeout: 10) }
+        subject { avro.register_schema(schema_name: schema_name, namespace: namespace, subject: subj, write_timeout: 10) }
 
         let(:subj) { 'subject' }
 
         before do
-          allow(registry).to receive(:register).with(subj, schema, { read_timeout: 10 }).and_return(schema_id)
+          allow(registry).to receive(:register).with(subj, schema, { write_timeout: 10 }).and_return(schema_id)
         end
 
         it 'registers schema in registry' do

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -163,14 +163,14 @@ describe AvroTurf::Messaging do
       allow(registry).to receive(:register).and_call_original
       message = { "full_name" => "John Doe" }
       avro.encode(message, schema_name: "person")
-      expect(registry).to have_received(:register).with("person", anything)
+      expect(registry).to have_received(:register).with("person", anything, { read_timeout: nil })
     end
 
     it "allows specifying a schema registry subject" do
       allow(registry).to receive(:register).and_call_original
       message = { "full_name" => "John Doe" }
       avro.encode(message, schema_name: "person", subject: "people")
-      expect(registry).to have_received(:register).with("people", anything)
+      expect(registry).to have_received(:register).with("people", anything, { read_timeout: nil })
     end
   end
 
@@ -277,14 +277,14 @@ describe AvroTurf::Messaging do
         allow(registry).to receive(:register).and_call_original
         message = { "full_name" => "John Doe" }
         avro.encode(message, schema_name: "person")
-        expect(registry).to have_received(:register).with("person", anything)
+        expect(registry).to have_received(:register).with("person", anything, { read_timeout: nil })
       end
 
       it "allows specifying a schema registry subject" do
         allow(registry).to receive(:register).and_call_original
         message = { "full_name" => "John Doe" }
         avro.encode(message, schema_name: "person", subject: "people")
-        expect(registry).to have_received(:register).with("people", anything)
+        expect(registry).to have_received(:register).with("people", anything, { read_timeout: nil })
       end
     end
 
@@ -384,10 +384,10 @@ describe AvroTurf::Messaging do
       end
 
       context 'when subject is not set' do
-        subject { avro.register_schema(schema_name: schema_name, namespace: namespace) }
+        subject { avro.register_schema(schema_name: schema_name, namespace: namespace, read_timeout: 10) }
 
         before do
-          allow(registry).to receive(:register).with(schema.fullname, schema).and_return(schema_id)
+          allow(registry).to receive(:register).with(schema.fullname, schema, { read_timeout: 10 }).and_return(schema_id)
         end
 
         it 'registers schema in registry' do
@@ -396,12 +396,12 @@ describe AvroTurf::Messaging do
       end
 
       context 'when subject is set' do
-        subject { avro.register_schema(schema_name: schema_name, namespace: namespace, subject: subj) }
+        subject { avro.register_schema(schema_name: schema_name, namespace: namespace, subject: subj, read_timeout: 10) }
 
         let(:subj) { 'subject' }
 
         before do
-          allow(registry).to receive(:register).with(subj, schema).and_return(schema_id)
+          allow(registry).to receive(:register).with(subj, schema, { read_timeout: 10 }).and_return(schema_id)
         end
 
         it 'registers schema in registry' do

--- a/spec/support/confluent_schema_registry_context.rb
+++ b/spec/support/confluent_schema_registry_context.rb
@@ -4,6 +4,7 @@ shared_examples_for "a confluent schema registry client" do
   let(:logger) { Logger.new(StringIO.new) }
   let(:registry_url) { "http://registry.example.com" }
   let(:subject_name) { "some-subject" }
+  let(:connection_options) { { read_timeout: 10 } }
   let(:schema) do
     {
       type: "record",
@@ -143,7 +144,7 @@ shared_examples_for "a confluent schema registry client" do
     end
 
     it "returns a specific version of a schema" do
-      expect(registry.subject_version(subject_name, 1))
+      expect(registry.subject_version(subject_name, 1, **connection_options))
         .to eq(JSON.parse(expected))
     end
 
@@ -158,7 +159,7 @@ shared_examples_for "a confluent schema registry client" do
       end
 
       it "returns the latest version" do
-        expect(registry.subject_version(subject_name))
+        expect(registry.subject_version(subject_name, **connection_options))
           .to eq(JSON.parse(expected))
       end
     end
@@ -166,7 +167,7 @@ shared_examples_for "a confluent schema registry client" do
     context "when the subject does not exist" do
       it "raises an error" do
         expect do
-          registry.subject_version('missing')
+          registry.subject_version('missing', **connection_options)
         end.to raise_error(Excon::Errors::NotFound)
       end
     end
@@ -174,7 +175,7 @@ shared_examples_for "a confluent schema registry client" do
     context "when the version does not exist" do
       it "raises an error" do
         expect do
-          registry.subject_version(subject_name, 3)
+          registry.subject_version(subject_name, 3, **connection_options)
         end.to raise_error(Excon::Errors::NotFound)
       end
     end

--- a/spec/support/confluent_schema_registry_context.rb
+++ b/spec/support/confluent_schema_registry_context.rb
@@ -33,7 +33,7 @@ shared_examples_for "a confluent schema registry client" do
 
   describe "#register and #fetch" do
     it "allows registering a schema" do
-      id = registry.register(subject_name, schema)
+      id = registry.register(subject_name, schema, **connection_options)
       fetched_schema = registry.fetch(id, **connection_options)
 
       expect(fetched_schema).to eq(schema)
@@ -43,7 +43,7 @@ shared_examples_for "a confluent schema registry client" do
       let(:avro_schema) { Avro::Schema.parse(schema) }
 
       it "allows registration using an Avro::Schema" do
-        id = registry.register(subject_name, avro_schema)
+        id = registry.register(subject_name, avro_schema, **connection_options)
         expect(registry.fetch(id, **connection_options)).to eq(avro_schema.to_s)
       end
 
@@ -53,7 +53,7 @@ shared_examples_for "a confluent schema registry client" do
         end
 
         it "allows registering an Avro schema" do
-          id = registry.register(subject_name, avro_schema)
+          id = registry.register(subject_name, avro_schema, **connection_options)
           expect(registry.fetch(id, **connection_options)).to eq(avro_schema.to_s)
         end
       end
@@ -73,16 +73,16 @@ shared_examples_for "a confluent schema registry client" do
   describe "#subjects" do
     it "lists the subjects in the registry" do
       subjects = Array.new(2) { |n| "subject#{n}" }
-      subjects.each { |subject| registry.register(subject, schema) }
+      subjects.each { |subject| registry.register(subject, schema, **connection_options) }
       expect(registry.subjects).to be_json_eql(subjects.to_json)
     end
   end
 
   describe "#schema_subject_versions" do
     it "returns subject and version for a schema id" do
-      schema_id1 = registry.register(subject_name, { type: :record, name: "r1", fields: [] }.to_json)
-      registry.register(subject_name, { type: :record, name: "r2", fields: [] }.to_json)
-      schema_id2 = registry.register("other#{subject_name}", { type: :record, name: "r2", fields: [] }.to_json)
+      schema_id1 = registry.register(subject_name, { type: :record, name: "r1", fields: [] }.to_json, **connection_options)
+      registry.register(subject_name, { type: :record, name: "r2", fields: [] }.to_json, **connection_options)
+      schema_id2 = registry.register("other#{subject_name}", { type: :record, name: "r2", fields: [] }.to_json, **connection_options)
       expect(registry.schema_subject_versions(schema_id1)).to eq([
         'subject' => subject_name,
         'version' => 1
@@ -109,7 +109,8 @@ shared_examples_for "a confluent schema registry client" do
     it "lists all the versions for the subject" do
       2.times do |n|
         registry.register(subject_name,
-                          { type: :record, name: "r#{n}", fields: [] }.to_json)
+                          { type: :record, name: "r#{n}", fields: [] }.to_json,
+                          **connection_options)
       end
       expect(registry.subject_versions(subject_name))
         .to be_json_eql((1..2).to_a.to_json)
@@ -128,10 +129,10 @@ shared_examples_for "a confluent schema registry client" do
 
   describe "#subject_version" do
     let!(:schema_id1) do
-      registry.register(subject_name, { type: :record, name: "r0", fields: [] }.to_json)
+      registry.register(subject_name, { type: :record, name: "r0", fields: [] }.to_json, **connection_options)
     end
     let!(:schema_id2) do
-      registry.register(subject_name, { type: :record, name: "r1", fields: [] }.to_json)
+      registry.register(subject_name, { type: :record, name: "r1", fields: [] }.to_json, **connection_options)
     end
 
     let(:expected) do
@@ -183,7 +184,7 @@ shared_examples_for "a confluent schema registry client" do
 
   describe "#check" do
     context "when the schema exists" do
-      let!(:schema_id) { registry.register(subject_name, schema) }
+      let!(:schema_id) { registry.register(subject_name, schema, **connection_options) }
       let(:expected) do
         {
           subject: subject_name,

--- a/spec/support/confluent_schema_registry_context.rb
+++ b/spec/support/confluent_schema_registry_context.rb
@@ -4,7 +4,7 @@ shared_examples_for "a confluent schema registry client" do
   let(:logger) { Logger.new(StringIO.new) }
   let(:registry_url) { "http://registry.example.com" }
   let(:subject_name) { "some-subject" }
-  let(:connection_options) { { read_timeout: 10 } }
+  let(:connection_options) { { foo: :bar } }
   let(:schema) do
     {
       type: "record",

--- a/spec/support/confluent_schema_registry_context.rb
+++ b/spec/support/confluent_schema_registry_context.rb
@@ -34,7 +34,7 @@ shared_examples_for "a confluent schema registry client" do
   describe "#register and #fetch" do
     it "allows registering a schema" do
       id = registry.register(subject_name, schema)
-      fetched_schema = registry.fetch(id)
+      fetched_schema = registry.fetch(id, **connection_options)
 
       expect(fetched_schema).to eq(schema)
     end
@@ -44,7 +44,7 @@ shared_examples_for "a confluent schema registry client" do
 
       it "allows registration using an Avro::Schema" do
         id = registry.register(subject_name, avro_schema)
-        expect(registry.fetch(id)).to eq(avro_schema.to_s)
+        expect(registry.fetch(id, **connection_options)).to eq(avro_schema.to_s)
       end
 
       context "with ActiveSupport present" do
@@ -54,7 +54,7 @@ shared_examples_for "a confluent schema registry client" do
 
         it "allows registering an Avro schema" do
           id = registry.register(subject_name, avro_schema)
-          expect(registry.fetch(id)).to eq(avro_schema.to_s)
+          expect(registry.fetch(id, **connection_options)).to eq(avro_schema.to_s)
         end
       end
     end
@@ -64,7 +64,7 @@ shared_examples_for "a confluent schema registry client" do
     context "when the schema does not exist" do
       it "raises an error" do
         expect do
-          registry.fetch(-1)
+          registry.fetch(-1, **connection_options)
         end.to raise_error(Excon::Errors::NotFound)
       end
     end


### PR DESCRIPTION
Hey there 👋 

I'm creating this PR to add the ability of setting Excon's connection options.

With this ability I wish to set a smaller timeout in case the schema registry is unavailable, so that we can have a "fail fast" approach.
I'd rather set the timeout to something like 10 seconds and retry 5 times, rather than having a timeout of 60 seconds (default value) with only 1 attempt.

Please feel free to provide any feedback you deem relevant.

Thanks 😁 

---

TODO:
- [ ] Update README