### PR TITLE
Add connect_timeout option for Schema Registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `connect_timeout` parameter to `AvroTurf::Messaging` to set the timeout for the connection to the schema registry (#197)
+
 ## v1.11.0
 
 - Add `decode_all` and `decode_all_from_stream` methods to return all entries in a data file (#194)

--- a/lib/avro_turf/confluent_schema_registry.rb
+++ b/lib/avro_turf/confluent_schema_registry.rb
@@ -15,7 +15,8 @@ class AvroTurf::ConfluentSchemaRegistry
     client_key_pass: nil,
     client_cert_data: nil,
     client_key_data: nil,
-    path_prefix: nil
+    path_prefix: nil,
+    connect_timeout: nil
   )
     @path_prefix = path_prefix
     @logger = logger
@@ -33,7 +34,8 @@ class AvroTurf::ConfluentSchemaRegistry
       client_key: client_key,
       client_key_pass: client_key_pass,
       client_cert_data: client_cert_data,
-      client_key_data: client_key_data
+      client_key_data: client_key_data,
+      connect_timeout: connect_timeout
     )
   end
 

--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -55,6 +55,7 @@ class AvroTurf
     # client_key_pass      - Password to go with client_key (optional).
     # client_cert_data     - In-memory client certificate (optional).
     # client_key_data      - In-memory client private key to go with client_cert_data (optional).
+    # connect_timeout      - Timeout to use in the connection with the schema registry (optional).
     def initialize(
       registry: nil,
       registry_url: nil,
@@ -71,7 +72,8 @@ class AvroTurf
       client_key: nil,
       client_key_pass: nil,
       client_cert_data: nil,
-      client_key_data: nil
+      client_key_data: nil,
+      connect_timeout: nil
     )
       @logger = logger || Logger.new($stderr)
       @namespace = namespace
@@ -89,7 +91,8 @@ class AvroTurf
           client_key_pass: client_key_pass,
           client_cert_data: client_cert_data,
           client_key_data: client_key_data,
-          path_prefix: registry_path_prefix
+          path_prefix: registry_path_prefix,
+          connect_timeout: connect_timeout
         )
       )
       @schemas_by_id = {}

--- a/spec/confluent_schema_registry_spec.rb
+++ b/spec/confluent_schema_registry_spec.rb
@@ -8,6 +8,7 @@ describe AvroTurf::ConfluentSchemaRegistry do
   let(:client_cert) { "test client cert" }
   let(:client_key) { "test client key" }
   let(:client_key_pass) { "test client key password" }
+  let(:connect_timeout) { 10 }
 
   it_behaves_like "a confluent schema registry client" do
     let(:registry) {
@@ -27,6 +28,17 @@ describe AvroTurf::ConfluentSchemaRegistry do
         registry_url,
         user: user,
         password: password,
+      )
+    }
+  end
+
+  it_behaves_like "a confluent schema registry client" do
+    let(:registry) {
+      described_class.new(
+        registry_url,
+        user: user,
+        password: password,
+        connect_timeout: connect_timeout
       )
     }
   end

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -445,7 +445,7 @@ describe AvroTurf::Messaging do
 
     it 'passes the connect timeout setting to Excon' do
       expect(Excon).to receive(:new).with(anything, hash_including(connect_timeout: 10)).and_call_original
-      avro.encode(message, schema_name: "person")
+      avro
     end
   end
 end

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -425,4 +425,27 @@ describe AvroTurf::Messaging do
     it_behaves_like 'encoding and decoding with the schema from registry'
     it_behaves_like 'encoding and decoding with the schema_id from registry'
   end
+
+  context 'with a connect timeout' do
+    let(:avro) {
+      AvroTurf::Messaging.new(
+        registry_url: registry_url,
+        schemas_path: "spec/schemas",
+        logger: logger,
+        client_cert: client_cert,
+        client_key: client_key,
+        client_key_pass: client_key_pass,
+        connect_timeout: 10
+      )
+    }
+
+    it_behaves_like "encoding and decoding with the schema from schema store"
+    it_behaves_like 'encoding and decoding with the schema from registry'
+    it_behaves_like 'encoding and decoding with the schema_id from registry'
+
+    it 'passes the connect timeout setting to Excon' do
+      expect(Excon).to receive(:new).with(anything, hash_including(connect_timeout: 10)).and_call_original
+      avro.encode(message, schema_name: "person")
+    end
+  end
 end


### PR DESCRIPTION
Hey there 👋

I'm creating this PR to add the ability of setting Excon's timeout connection option.

With this ability I wish to set a smaller timeout in case the schema registry is unavailable, so that we can have a "fail fast" approach.
I'd rather set the timeout to something like 10 seconds and retry 5 times, rather than having a timeout of 60 seconds (default value) with only 1 attempt.

Please feel free to provide any feedback you deem relevant.

Thanks 😁

---

**Notes:**
This was discussed in the past in https://github.com/dasch/avro_turf/issues/62.
My first PR (https://github.com/dasch/avro_turf/pull/196) had a different, not optimal, approach as noted by @dasch.