### PR TITLE
Set `idempotent: true` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Set `idempotent: true` for the request except one that registers a new schema (#199)
+
 ## v1.12.0
 
 - Add `connect_timeout` parameter to `AvroTurf::Messaging` to set the timeout for the connection to the schema registry (#197)

--- a/lib/avro_turf/confluent_schema_registry.rb
+++ b/lib/avro_turf/confluent_schema_registry.rb
@@ -41,7 +41,7 @@ class AvroTurf::ConfluentSchemaRegistry
 
   def fetch(id)
     @logger.info "Fetching schema with id #{id}"
-    data = get("/schemas/ids/#{id}")
+    data = get("/schemas/ids/#{id}", idempotent: true)
     data.fetch("schema")
   end
 
@@ -57,29 +57,30 @@ class AvroTurf::ConfluentSchemaRegistry
 
   # List all subjects
   def subjects
-    get('/subjects')
+    get('/subjects', idempotent: true)
   end
 
   # List all versions for a subject
   def subject_versions(subject)
-    get("/subjects/#{subject}/versions")
+    get("/subjects/#{subject}/versions", idempotent: true)
   end
 
   # Get a specific version for a subject
   def subject_version(subject, version = 'latest')
-    get("/subjects/#{subject}/versions/#{version}")
+    get("/subjects/#{subject}/versions/#{version}", idempotent: true)
   end
 
   # Get the subject and version for a schema id
   def schema_subject_versions(schema_id)
-    get("/schemas/ids/#{schema_id}/versions")
+    get("/schemas/ids/#{schema_id}/versions", idempotent: true)
   end
 
   # Check if a schema exists. Returns nil if not found.
   def check(subject, schema)
     data = post("/subjects/#{subject}",
                 expects: [200, 404],
-                body: { schema: schema.to_s }.to_json)
+                body: { schema: schema.to_s }.to_json,
+                idempotent: true)
     data unless data.has_key?("error_code")
   end
 
@@ -91,28 +92,28 @@ class AvroTurf::ConfluentSchemaRegistry
   # http://docs.confluent.io/3.1.2/schema-registry/docs/api.html#compatibility
   def compatible?(subject, schema, version = 'latest')
     data = post("/compatibility/subjects/#{subject}/versions/#{version}",
-                expects: [200, 404], body: { schema: schema.to_s }.to_json)
+                expects: [200, 404], body: { schema: schema.to_s }.to_json, idempotent: true)
     data.fetch('is_compatible', false) unless data.has_key?('error_code')
   end
 
   # Get global config
   def global_config
-    get("/config")
+    get("/config", idempotent: true)
   end
 
   # Update global config
   def update_global_config(config)
-    put("/config", body: config.to_json)
+    put("/config", body: config.to_json, idempotent: true)
   end
 
   # Get config for subject
   def subject_config(subject)
-    get("/config/#{subject}")
+    get("/config/#{subject}", idempotent: true)
   end
 
   # Update config for subject
   def update_subject_config(subject, config)
-    put("/config/#{subject}", body: config.to_json)
+    put("/config/#{subject}", body: config.to_json, idempotent: true)
   end
 
   private


### PR DESCRIPTION
related to  https://github.com/dasch/avro_turf/pull/198

I'd like to pass Excon options(e.g. `idempotent: true`) to the CachedConfluentSchemaRegistry methods so that the Excon can retry the failed requests automatically.

In this commit, I set `idempotent: true` for every request to the SchemeRegistry.

By the way, I'm not sure whether it is safe for us to set  `idempotent: true` to requests for the SchemaRegistry.
ref. https://docs.confluent.io/platform/current/schema-registry/develop/api.html