### PR TITLE
Use connect_timeout for Excon's dns_timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Set `idempotent: true` for the request except one that registers a new schema (#199)
+- Use `connect_timeout` for `Excon`'s `dns_timeouts` that set the timeout for the connection to the Domain Name Server (#201)
 
 ## v1.12.0
 

--- a/avro_turf.gemspec
+++ b/avro_turf.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "avro", ">= 1.8.0", "< 1.12"
-  spec.add_dependency "excon", "~> 0.71"
+  spec.add_dependency "excon", "~> 0.103"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/lib/avro_turf/confluent_schema_registry.rb
+++ b/lib/avro_turf/confluent_schema_registry.rb
@@ -35,7 +35,8 @@ class AvroTurf::ConfluentSchemaRegistry
       client_key_pass: client_key_pass,
       client_cert_data: client_cert_data,
       client_key_data: client_key_data,
-      connect_timeout: connect_timeout
+      connect_timeout: connect_timeout,
+      dns_timeouts: connect_timeout
     )
   end
 

--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -55,7 +55,7 @@ class AvroTurf
     # client_key_pass      - Password to go with client_key (optional).
     # client_cert_data     - In-memory client certificate (optional).
     # client_key_data      - In-memory client private key to go with client_cert_data (optional).
-    # connect_timeout      - Timeout to use in the connection with the schema registry (optional).
+    # connect_timeout      - Timeout to use in the connection with the domain name server and the schema registry (optional).
     def initialize(
       registry: nil,
       registry_url: nil,

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -444,7 +444,7 @@ describe AvroTurf::Messaging do
     it_behaves_like 'encoding and decoding with the schema_id from registry'
 
     it 'passes the connect timeout setting to Excon' do
-      expect(Excon).to receive(:new).with(anything, hash_including(connect_timeout: 10)).and_call_original
+      expect(Excon).to receive(:new).with(anything, hash_including(connect_timeout: 10, dns_timeouts: 10)).and_call_original
       avro
     end
   end


### PR DESCRIPTION
Hey there 👋 

As discussed in #200, I'm using `connect_timeout` to also set `Excon`'s `dns_timeouts`.

Thanks 😁 