### PR TITLE
Add `resolv_resolver` parameter to `AvroTurf::Messaging`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `resolv_resolver` parameter to `AvroTurf::Messaging` to make use of custom domain name resolvers and their options, for example `nameserver` and `timeouts` (#202)
+- Stop using `Excon`'s `dns_timeouts` in favour of `resolv_resolver` because `dns_timeouts` is now deprecated due to https://github.com/excon/excon/issues/832 (#202)
+
 ## v1.13.0
 
 - Set `idempotent: true` for the request except one that registers a new schema (#199)

--- a/avro_turf.gemspec
+++ b/avro_turf.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "avro", ">= 1.8.0", "< 1.12"
-  spec.add_dependency "excon", "~> 0.103"
+  spec.add_dependency "excon", "~> 0.104"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sinatra"
   spec.add_development_dependency "json_spec"
   spec.add_development_dependency "rack-test"
+  spec.add_development_dependency "resolv"
 
   spec.post_install_message = %{
 avro_turf v0.8.0 deprecates the names AvroTurf::SchemaRegistry,

--- a/lib/avro_turf/confluent_schema_registry.rb
+++ b/lib/avro_turf/confluent_schema_registry.rb
@@ -16,7 +16,8 @@ class AvroTurf::ConfluentSchemaRegistry
     client_cert_data: nil,
     client_key_data: nil,
     path_prefix: nil,
-    connect_timeout: nil
+    connect_timeout: nil,
+    resolv_resolver: nil
   )
     @path_prefix = path_prefix
     @logger = logger
@@ -36,7 +37,7 @@ class AvroTurf::ConfluentSchemaRegistry
       client_cert_data: client_cert_data,
       client_key_data: client_key_data,
       connect_timeout: connect_timeout,
-      dns_timeouts: connect_timeout
+      resolv_resolver: resolv_resolver
     )
   end
 

--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -55,7 +55,8 @@ class AvroTurf
     # client_key_pass      - Password to go with client_key (optional).
     # client_cert_data     - In-memory client certificate (optional).
     # client_key_data      - In-memory client private key to go with client_cert_data (optional).
-    # connect_timeout      - Timeout to use in the connection with the domain name server and the schema registry (optional).
+    # connect_timeout      - Timeout to use in the connection with the schema registry (optional).
+    # resolv_resolver      - Custom domain name resolver (optional).
     def initialize(
       registry: nil,
       registry_url: nil,
@@ -73,7 +74,8 @@ class AvroTurf
       client_key_pass: nil,
       client_cert_data: nil,
       client_key_data: nil,
-      connect_timeout: nil
+      connect_timeout: nil,
+      resolv_resolver: nil
     )
       @logger = logger || Logger.new($stderr)
       @namespace = namespace
@@ -92,7 +94,8 @@ class AvroTurf
           client_cert_data: client_cert_data,
           client_key_data: client_key_data,
           path_prefix: registry_path_prefix,
-          connect_timeout: connect_timeout
+          connect_timeout: connect_timeout,
+          resolv_resolver: resolv_resolver
         )
       )
       @schemas_by_id = {}

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -444,7 +444,31 @@ describe AvroTurf::Messaging do
     it_behaves_like 'encoding and decoding with the schema_id from registry'
 
     it 'passes the connect timeout setting to Excon' do
-      expect(Excon).to receive(:new).with(anything, hash_including(connect_timeout: 10, dns_timeouts: 10)).and_call_original
+      expect(Excon).to receive(:new).with(anything, hash_including(connect_timeout: 10)).and_call_original
+      avro
+    end
+  end
+
+  context 'with a custom domain name resolver' do
+    let(:resolv_resolver) { Resolv.new([Resolv::Hosts.new, Resolv::DNS.new(nameserver: ['127.0.0.1', '127.0.0.1'])]) }
+    let(:avro) {
+      AvroTurf::Messaging.new(
+        registry_url: registry_url,
+        schemas_path: "spec/schemas",
+        logger: logger,
+        client_cert: client_cert,
+        client_key: client_key,
+        client_key_pass: client_key_pass,
+        resolv_resolver: resolv_resolver
+      )
+    }
+
+    it_behaves_like "encoding and decoding with the schema from schema store"
+    it_behaves_like 'encoding and decoding with the schema from registry'
+    it_behaves_like 'encoding and decoding with the schema_id from registry'
+
+    it 'passes the domain name resolver setting to Excon' do
+      expect(Excon).to receive(:new).with(anything, hash_including(resolv_resolver: resolv_resolver)).and_call_original
       avro
     end
   end


### PR DESCRIPTION
## Goal

Start using the new `resolv_resolver` parameter of `Excon` in order to be able to use custom domain name resolvers and their options, like `nameserver` and `timeouts`.
Also, address the new deprecation warning of `dns_timeouts` being deprecated.


## Description

In this PR we're starting to use `Excon`'s `resolv_resolver` parameter to pass custom domain name resolvers and options.
We also stop using `dns_timeouts` since it has been deprecated in `Excon` `v0.104.0` (see why in https://github.com/excon/excon/issues/832).

I've updated the changelog and the specs as well.

Please let me know your feedback 🙇 
