### PR TITLE
Clarify README docs for specifying schema name in schema registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,10 +175,14 @@ avro = AvroTurf::Messaging.new(registry_url: "http://my-registry:8081/")
 data = avro.encode({ "title" => "hello, world" }, schema_name: "greeting")
 
 # If you don't want to automatically register new schemas, you can pass explicitly
-# subject and version to specify which schema should be used for encoding.
+# both subject and version to specify which schema should be used for encoding.
 # It will fetch that schema from the registry and cache it. Subsequent instances
 # of the same schema version will be served by the cache.
 data = avro.encode({ "title" => "hello, world" }, subject: 'greeting', version: 1)
+
+# If you want to use a specific local schema, but register it with a different name in the
+# registry, then provide a subject and a schema_name, but not a version
+data = avro.encode({ "title" => "hello, world" }, subject: "greeting-value", schema_name: "greeting")
 
 # You can also pass explicitly schema_id to specify which schema
 # should be used for encoding.


### PR DESCRIPTION
Firstly, 👋 hi @dasch! Hope alls well over your way!

We currently reference local schemas in our repository, and use avro_turf. We noticed that when following the Confluent Schema Registry convention of `<topic>-key` and `<topic>-value` the docs were a little bit confusing about how we'd reference a record typed `Thing`, but wanting to publish it to a topic called `things`.

```rb
avro.encode({ thing: { id: 1, name: "hello!" } }, subject: "things-value", schema_name: "Thing")
```

This works as expected, but I figured out from reading the code rather an the docs, so I thought I'd add the extra example.