### PR TITLE
Add compatibility with Avro v1.12

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6, 2.7, "3.0", 3.1, 3.2]
+        ruby: [3.0, 3.1, 3.2, 3.3]
 
     steps:
     - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add compatibility with Avro v1.12.x.
+
 ## v1.15.0
 
 - Use `default_namespace` from exception to load nested schemas from the correct namespace. (#203)

--- a/avro_turf.gemspec
+++ b/avro_turf.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "avro", ">= 1.11.3", "< 1.12"
+  spec.add_dependency "avro", ">= 1.11.3", "< 1.13"
   spec.add_dependency "excon", "~> 0.104"
 
   spec.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
A new major release of Avro was pushed today. Some bug fixes, but no major changes for Ruby Avro.

As part of this change I updated the CI workflow to drop EOL Ruby versions and added 3.3.