### PR TITLE
Add `read_only` option to `encode` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ avro.encode({ "name" => "Jane", "age" => 28 }, schema_name: "person")
 # Data can be validated before encoding to get a description of problem through
 # Avro::SchemaValidator::ValidationError exception
 avro.encode({ "titl" => "hello, world" }, schema_name: "person", validate: true)
+
+# If you do not want to register the schema in case it does not exist, you can pass the read_only option
+avro.encode({ "name" => "Jane", "age" => 28 }, schema_name: "person", read_only: true)
 ```
 
 ### Inter-schema references

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ avro.encode({ "name" => "Jane", "age" => 28 }, schema_name: "person")
 # Avro::SchemaValidator::ValidationError exception
 avro.encode({ "titl" => "hello, world" }, schema_name: "person", validate: true)
 
-# If you do not want to register the schema in case it does not exist, you can pass the read_only option
-avro.encode({ "name" => "Jane", "age" => 28 }, schema_name: "person", read_only: true)
+# If you do not want to register the schema in case it does not exist, you can pass the register_schemas option as false
+avro.encode({ "name" => "Jane", "age" => 28 }, schema_name: "person", register_schemas: false)
 ```
 
 ### Inter-schema references

--- a/lib/avro_turf/cached_confluent_schema_registry.rb
+++ b/lib/avro_turf/cached_confluent_schema_registry.rb
@@ -17,11 +17,15 @@ class AvroTurf::CachedConfluentSchemaRegistry
   end
 
   # Delegate the following methods to the upstream
-  %i(subjects subject_versions schema_subject_versions check compatible?
+  %i(subjects subject_versions schema_subject_versions compatible?
      global_config update_global_config subject_config update_subject_config).each do |name|
     define_method(name) do |*args|
       instance_variable_get(:@upstream).send(name, *args)
     end
+  end
+
+  def check(subject, schema)
+    @cache.lookup_data_by_schema(subject, schema) || @cache.store_data_by_schema(subject, schema, @upstream.check(subject, schema))
   end
 
   def fetch(id)

--- a/lib/avro_turf/disk_cache.rb
+++ b/lib/avro_turf/disk_cache.rb
@@ -16,6 +16,10 @@ class AvroTurf::DiskCache
 
     @schemas_by_subject_version_path = File.join(disk_path, 'schemas_by_subject_version.json')
     @schemas_by_subject_version = {}
+
+    @data_by_schema_path = File.join(disk_path, 'data_by_schema.json')
+    hash = read_from_disk_cache(@data_by_schema_path)
+    @data_by_schema = hash || {}
   end
 
   # override
@@ -40,6 +44,12 @@ class AvroTurf::DiskCache
     @ids_by_schema[key]
   end
 
+  # override to use a json serializable cache key
+  def lookup_data_by_schema(subject, schema)
+    key = "#{subject}#{schema}"
+    @data_by_schema[key]
+  end
+
   # override to use a json serializable cache key and update the file cache
   def store_by_schema(subject, schema, id)
     key = "#{subject}#{schema}"
@@ -47,6 +57,15 @@ class AvroTurf::DiskCache
 
     write_to_disk_cache(@ids_by_schema_path, @ids_by_schema)
     id
+  end
+
+  def store_data_by_schema(subject, schema, data)
+    return unless data
+
+    key = "#{subject}#{schema}"
+    @data_by_schema[key] = data
+    write_to_disk_cache(@data_by_schema_path, @data_by_schema)
+    data
   end
 
   # checks instance var (in-memory cache) for schema

--- a/lib/avro_turf/in_memory_cache.rb
+++ b/lib/avro_turf/in_memory_cache.rb
@@ -6,6 +6,7 @@ class AvroTurf::InMemoryCache
     @schemas_by_id = {}
     @ids_by_schema = {}
     @schema_by_subject_version = {}
+    @data_by_schema = {}
   end
 
   def lookup_by_id(id)
@@ -21,9 +22,21 @@ class AvroTurf::InMemoryCache
     @ids_by_schema[key]
   end
 
+  def lookup_data_by_schema(subject, schema)
+    key = [subject, schema]
+    @data_by_schema[key]
+  end
+
   def store_by_schema(subject, schema, id)
     key = [subject, schema]
     @ids_by_schema[key] = id
+  end
+
+  def store_data_by_schema(subject, schema, data)
+    return unless data
+
+    key = [subject, schema]
+    @data_by_schema[key] = data
   end
 
   def lookup_by_version(subject, version)

--- a/lib/avro_turf/in_memory_cache.rb
+++ b/lib/avro_turf/in_memory_cache.rb
@@ -1,7 +1,6 @@
 # A cache for the CachedConfluentSchemaRegistry.
 # Simply stores the schemas and ids in in-memory hashes.
 class AvroTurf::InMemoryCache
-
   def initialize
     @schemas_by_id = {}
     @ids_by_schema = {}

--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -106,32 +106,32 @@ class AvroTurf
 
     # Encodes a message using the specified schema.
     #
-    # message     - The message that should be encoded. Must be compatible with
-    #               the schema.
-    # schema_name - The String name of the schema that should be used to encode
-    #               the data.
-    # namespace   - The namespace of the schema (optional).
-    # subject     - The subject name the schema should be registered under in
-    #               the schema registry (optional).
-    # version     - The integer version of the schema that should be used to decode
-    #               the data. Must match the schema used when encoding (optional).
-    # schema_id   - The integer id of the schema that should be used to encode
-    #               the data.
-    # validate    - The boolean for performing complete message validation before
-    #               encoding it, Avro::SchemaValidator::ValidationError with
-    #               a descriptive message will be raised in case of invalid message.
-    # read_only   - The boolean that indicates whether or not the schema should be
-    #               registered in case it does not exist, or if it should be fetched
-    #               from the registry without registering it (read_only: true).
+    # message           - The message that should be encoded. Must be compatible with
+    #                     the schema.
+    # schema_name       - The String name of the schema that should be used to encode
+    #                     the data.
+    # namespace         - The namespace of the schema (optional).
+    # subject           - The subject name the schema should be registered under in
+    #                     the schema registry (optional).
+    # version           - The integer version of the schema that should be used to decode
+    #                     the data. Must match the schema used when encoding (optional).
+    # schema_id         - The integer id of the schema that should be used to encode
+    #                     the data.
+    # validate          - The boolean for performing complete message validation before
+    #                     encoding it, Avro::SchemaValidator::ValidationError with
+    #                     a descriptive message will be raised in case of invalid message.
+    # register_schemas  - The boolean that indicates whether or not the schema should be
+    #                     registered in case it does not exist, or if it should be fetched
+    #                     from the registry without registering it (register_schemas: false).
     #
     # Returns the encoded data as a String.
     def encode(message, schema_name: nil, namespace: @namespace, subject: nil, version: nil, schema_id: nil, validate: false,
-               read_only: false)
+               register_schemas: true)
       schema, schema_id = if schema_id
         fetch_schema_by_id(schema_id)
       elsif subject && version
         fetch_schema(subject: subject, version: version)
-      elsif schema_name && read_only
+      elsif schema_name && !register_schemas
         fetch_schema_by_body(subject: subject, schema_name: schema_name, namespace: namespace)
       elsif schema_name
         register_schema(subject: subject, schema_name: schema_name, namespace: namespace)

--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -239,7 +239,7 @@ class AvroTurf
       schema_data = @registry.check(subject || schema.fullname, schema)
       raise SchemaNotFoundError.new("Schema with structure: #{schema} not found on registry") unless schema_data
 
-      [schema, schema_data.fetch('id')]
+      [schema, schema_data["id"]]
     end
 
     # Schemas are registered under the full name of the top level Avro record

--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -120,13 +120,19 @@ class AvroTurf
     # validate    - The boolean for performing complete message validation before
     #               encoding it, Avro::SchemaValidator::ValidationError with
     #               a descriptive message will be raised in case of invalid message.
+    # read_only   - The boolean that indicates whether or not the schema should be
+    #               registered in case it does not exist, or if it should be fetched
+    #               from the registry without registering it (read_only: true).
     #
     # Returns the encoded data as a String.
-    def encode(message, schema_name: nil, namespace: @namespace, subject: nil, version: nil, schema_id: nil, validate: false)
+    def encode(message, schema_name: nil, namespace: @namespace, subject: nil, version: nil, schema_id: nil, validate: false,
+               read_only: false)
       schema, schema_id = if schema_id
         fetch_schema_by_id(schema_id)
       elsif subject && version
         fetch_schema(subject: subject, version: version)
+      elsif schema_name && read_only
+        fetch_schema_by_body(subject: subject, schema_name: schema_name, namespace: namespace)
       elsif schema_name
         register_schema(subject: subject, schema_name: schema_name, namespace: namespace)
       else
@@ -226,6 +232,14 @@ class AvroTurf
         Avro::Schema.parse(schema_json)
       end
       [schema, schema_id]
+    end
+
+    def fetch_schema_by_body(schema_name:, subject: nil, namespace: nil)
+      schema = @schema_store.find(schema_name, namespace)
+      schema_data = @registry.check(subject || schema.fullname, schema)
+      raise SchemaNotFoundError.new("Schema with structure: #{schema} not found on registry") unless schema_data
+
+      [schema, schema_data.fetch('id')]
     end
 
     # Schemas are registered under the full name of the top level Avro record

--- a/lib/avro_turf/test/fake_prefixed_confluent_schema_registry_server.rb
+++ b/lib/avro_turf/test/fake_prefixed_confluent_schema_registry_server.rb
@@ -64,7 +64,8 @@ class FakePrefixedConfluentSchemaRegistryServer < FakeConfluentSchemaRegistrySer
 
     # Note: this does not actually handle the same schema registered under
     # multiple subjects
-    schema_id = SCHEMAS.index(schema)
+    context, _subject = parse_qualified_subject(params[:subject])
+    schema_id = SCHEMAS[context].index(schema)
 
     halt(404, SCHEMA_NOT_FOUND) unless schema_id
 

--- a/spec/cached_confluent_schema_registry_spec.rb
+++ b/spec/cached_confluent_schema_registry_spec.rb
@@ -38,11 +38,11 @@ describe AvroTurf::CachedConfluentSchemaRegistry do
   describe "#check" do
     let(:schema_data) do
       {
-        subject: subject_name,
-        version: 123,
-        id: id,
-        schema: schema
-      }.to_json
+        "subject" => subject_name,
+        "version" => 123,
+        "id" => id,
+        "schema" => schema
+      }
     end
 
     before do

--- a/spec/cached_confluent_schema_registry_spec.rb
+++ b/spec/cached_confluent_schema_registry_spec.rb
@@ -6,6 +6,7 @@ describe AvroTurf::CachedConfluentSchemaRegistry do
   let(:upstream) { instance_double(AvroTurf::ConfluentSchemaRegistry) }
   let(:registry) { described_class.new(upstream) }
   let(:id) { rand(999) }
+  let(:subject_name) { 'a_subject' }
   let(:schema) do
     {
       type: "record",
@@ -25,8 +26,6 @@ describe AvroTurf::CachedConfluentSchemaRegistry do
   end
 
   describe "#register" do
-    let(:subject_name) { "a_subject" }
-
     it "caches the result of register" do
       # multiple calls return same result, with only one upstream call
       allow(upstream).to receive(:register).with(subject_name, schema).and_return(id)
@@ -36,8 +35,29 @@ describe AvroTurf::CachedConfluentSchemaRegistry do
     end
   end
 
+  describe "#check" do
+    let(:schema_data) do
+      {
+        subject: subject_name,
+        version: 123,
+        id: id,
+        schema: schema
+      }.to_json
+    end
+
+    before do
+      allow(upstream).to receive(:check).with(subject_name, schema).and_return(schema_data)
+    end
+
+    it "caches the result of check" do
+      # multiple calls return same result, with only one upstream call
+      expect(registry.check(subject_name, schema)).to eq(schema_data)
+      expect(registry.check(subject_name, schema)).to eq(schema_data)
+      expect(upstream).to have_received(:check).exactly(1).times
+    end
+  end
+
   describe '#subject_version' do
-    let(:subject_name) { 'a_subject' }
     let(:version) { 1 }
     let(:schema_with_meta) do
       {

--- a/spec/disk_cached_confluent_schema_registry_spec.rb
+++ b/spec/disk_cached_confluent_schema_registry_spec.rb
@@ -226,20 +226,20 @@ describe AvroTurf::CachedConfluentSchemaRegistry do
     let(:city_name) { "a_city" }
     let(:schema_data) do
       {
-        subject: subject,
-        version: version,
-        id: id,
-        schema: schema
-      }.to_json
+        "subject" => subject,
+        "version" => version,
+        "id" => id,
+        "schema" => schema
+      }
     end
 
     let(:city_schema_data) do
       {
-        subject: city_name,
-        version: version,
-        id: city_id,
-        schema: city_schema
-      }.to_json
+        "subject" => city_name,
+        "version" => version,
+        "id" => city_id,
+        "schema" => city_schema
+      }
     end
 
     let(:cache_before) do

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -398,7 +398,7 @@ describe AvroTurf::Messaging do
           "subject" => subject_name,
           "version" => 123,
           "id" => city_schema_id,
-          "schema" => city_schema.to_s
+          "schema" => city_schema
         }
       end
 

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -111,13 +111,13 @@ describe AvroTurf::Messaging do
       expect { avro.encode(message, subject: 'missing', version: 1) }.to raise_error(AvroTurf::SchemaNotFoundError)
     end
 
-    it 'raises AvroTurf::SchemaNotFoundError when the schema does not exist on registry and read_only true' do
-      expect { avro.encode(city_message, schema_name: 'city', read_only: true) }.
+    it 'raises AvroTurf::SchemaNotFoundError when the schema does not exist on registry and register_schemas false' do
+      expect { avro.encode(city_message, schema_name: 'city', register_schemas: false) }.
         to raise_error(AvroTurf::SchemaNotFoundError, "Schema with structure: #{city_schema} not found on registry")
     end
 
-    it 'encodes with read_only true when the schema exists on the registry' do
-      data = avro.encode(message, schema_name: 'person', read_only: true)
+    it 'encodes with register_schemas false when the schema exists on the registry' do
+      data = avro.encode(message, schema_name: 'person', register_schemas: false)
       expect(avro.decode(data, schema_name: 'person')).to eq message
     end
 

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -116,6 +116,11 @@ describe AvroTurf::Messaging do
         to raise_error(AvroTurf::SchemaNotFoundError, "Schema with structure: #{city_schema} not found on registry")
     end
 
+    it 'encodes with read_only true when the schema exists on the registry' do
+      data = avro.encode(message, schema_name: 'person', read_only: true)
+      expect(avro.decode(data, schema_name: 'person')).to eq message
+    end
+
     it 'caches parsed schemas for decoding' do
       data = avro.encode(message, subject: 'person', version: 1)
       avro.decode(data)


### PR DESCRIPTION
Hi!

I would like to add the possibility to **not** register a new schema when encoding a message and passing the `schema_name` option only.

The motivation for this is that most of the times the schema evolution (registering and updates) are done during the Continuous Delivery process (during deployments, right before putting the new application code live), since this process is very delicate and we do not want to risk accidentally evolving the schema when trying things out in the development phase, I think it's important to have the option to tell the library to use a `read_only` mode while encoding.

In my company, currently the applications do not have to keep track of the current `schema_id` or even the `version` of the schemas used. So generally we call the encode method with the following options:

```ruby
avro.encode(message_payload, schema_name: the_schema_name, validate: true)
```

The problem with this is that, if by any chance we're testing things out locally, there is a risk to trigger an evolution of the schema by registering a new version that was not ready to be evolved.

In order to avoid that, we want to provide the `read_only` option, which only in case of true checks if the schema is already registered (by using the existing `check` action) and caches the schema so that it's only checked once, if it exists, it returns the `schema_id` from there instead of attempting to register it.

This change is 100% backwards compatible, as the current behavior only changes if the user decides to pass the `read_only` option set to true.