### PR TITLE
Add ConfluentSchemaRegistry#compatibility_issues for debugging breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `compatibility_issues` method to `ConfluentSchemaRegistry` to debug compatibility issues between a schema versions for a given subject (#212)
+
 ## v1.17.0
 
 - Add `register_schemas` option to `encode` method [#210](https://github.com/dasch/avro_turf/pull/210)

--- a/README.md
+++ b/README.md
@@ -254,6 +254,9 @@ registry = AvroTurf::ConfluentSchemaRegistry.new("http://my-registry:8081/")
 
 # Returns true if the schema is compatible, nil if the subject or version is not registered, and false if incompatible.
 registry.compatible?("person", schema)
+
+# Returns an array of any breaking changes, nil if the subject or version is not registered
+registry.compatibility_issues("person", schema)
 ```
 
 The ConfluentSchemaRegistry client can also change the global compatibility level or the compatibility level for an individual subject using the [Config API](http://docs.confluent.io/3.1.2/schema-registry/docs/api.html#config):

--- a/lib/avro_turf/confluent_schema_registry.rb
+++ b/lib/avro_turf/confluent_schema_registry.rb
@@ -101,6 +101,18 @@ class AvroTurf::ConfluentSchemaRegistry
     data.fetch('is_compatible', false) unless data.has_key?('error_code')
   end
 
+  # Check for specific schema compatibility issues
+  # Returns:
+  # - nil if the subject or version does not exist
+  # - a list of compatibility issues
+  # https://docs.confluent.io/platform/current/schema-registry/develop/api.html#sr-api-compatibility
+  def compatibility_issues(subject, schema, version = 'latest')
+    data = post("/compatibility/subjects/#{@schema_context_prefix}#{subject}/versions/#{version}",
+      expects: [200, 404], body: { schema: schema.to_s }.to_json, query: { verbose: true }, idempotent: true)
+
+    data.fetch('messages', []) unless data.has_key?('error_code')
+  end
+
   # Get global config
   def global_config
     get("/config", idempotent: true)


### PR DESCRIPTION
I've been using AvroTurf in CI to fail the build on incompatible changes. The Confluent Schema Registry support a verbose output for the compatibility API, so it would be excellent to be able to include that in my build failures.

> **verbose (boolean)** – Add `?verbose=true` at the end of this request to output the reason a schema fails the compatibility test, in cases where it fails. The default is false (the reason a schema fails compatibility test is not given).

https://docs.confluent.io/platform/current/schema-registry/develop/api.html#sr-api-compatibility