### PR TITLE
Fix sinatra 4.1 host authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add `compatibility_issues` method to `ConfluentSchemaRegistry` to debug compatibility issues between a schema versions for a given subject (#212)
+- Update tests to support `sinatra` version 4.1 that includes a new `host_authorization` parameter to permit only authorized requests
 
 ## v1.17.0
 

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -1,7 +1,5 @@
 require 'webmock/rspec'
 require 'avro_turf/messaging'
-require 'avro_turf/test/fake_confluent_schema_registry_server'
-require 'avro_turf/test/fake_prefixed_confluent_schema_registry_server'
 
 describe AvroTurf::Messaging do
   let(:registry_url) { "http://registry.example.com" }
@@ -61,8 +59,8 @@ describe AvroTurf::Messaging do
   end
 
   before do
-    stub_request(:any, /^#{registry_url}/).to_rack(FakeConfluentSchemaRegistryServer)
-    FakeConfluentSchemaRegistryServer.clear
+    stub_request(:any, /^#{registry_url}/).to_rack(AuthorizedFakeConfluentSchemaRegistryServer)
+    AuthorizedFakeConfluentSchemaRegistryServer.clear
   end
 
   before do
@@ -474,8 +472,8 @@ describe AvroTurf::Messaging do
     }
 
     before do
-      stub_request(:any, /^#{registry_url}/).to_rack(FakePrefixedConfluentSchemaRegistryServer)
-      FakePrefixedConfluentSchemaRegistryServer.clear
+      stub_request(:any, /^#{registry_url}/).to_rack(AuthorizedFakePrefixedConfluentSchemaRegistryServer)
+      AuthorizedFakePrefixedConfluentSchemaRegistryServer.clear
     end
 
     it_behaves_like "encoding and decoding with the schema from schema store"

--- a/spec/support/authorized_fake_confluent_schema_registry_server.rb
+++ b/spec/support/authorized_fake_confluent_schema_registry_server.rb
@@ -1,0 +1,5 @@
+require 'avro_turf/test/fake_confluent_schema_registry_server'
+
+class AuthorizedFakeConfluentSchemaRegistryServer < FakeConfluentSchemaRegistryServer
+  set :host_authorization, permitted_hosts: ['example.org', 'registry.example.com']
+end

--- a/spec/support/authorized_fake_prefixed_confluent_schema_registry_server.rb
+++ b/spec/support/authorized_fake_prefixed_confluent_schema_registry_server.rb
@@ -1,0 +1,5 @@
+require 'avro_turf/test/fake_prefixed_confluent_schema_registry_server'
+
+class AuthorizedFakePrefixedConfluentSchemaRegistryServer < FakePrefixedConfluentSchemaRegistryServer
+  set :host_authorization, permitted_hosts: ['example.org', 'registry.example.com']
+end

--- a/spec/support/confluent_schema_registry_context.rb
+++ b/spec/support/confluent_schema_registry_context.rb
@@ -26,9 +26,9 @@ shared_examples_for "a confluent schema registry client" do |schema_context: nil
   before do
     stub_request(:any, /^#{registry_url}/)
       .with(headers: headers)
-      .to_rack(FakeConfluentSchemaRegistryServer)
+      .to_rack(AuthorizedFakeConfluentSchemaRegistryServer)
 
-    FakeConfluentSchemaRegistryServer.clear
+    AuthorizedFakeConfluentSchemaRegistryServer.clear
   end
 
   describe "#register and #fetch" do

--- a/spec/test/fake_confluent_schema_registry_server_spec.rb
+++ b/spec/test/fake_confluent_schema_registry_server_spec.rb
@@ -1,10 +1,9 @@
 require 'rack/test'
-require 'avro_turf/test/fake_confluent_schema_registry_server'
 
 describe FakeConfluentSchemaRegistryServer do
   include Rack::Test::Methods
 
-  def app; described_class; end
+  def app; AuthorizedFakeConfluentSchemaRegistryServer; end
 
   describe 'POST /subjects/:subject/versions' do
     it 'returns the same schema ID when invoked with same schema and same subject' do


### PR DESCRIPTION
Recent updates in `sinatra` introduced a new middleware to authenticate requests based on expected host headers to fix [CVE-2024-21510](https://github.com/sinatra/sinatra/pull/2053).

This new middleware adds a new configuration directive in the Sinatra service to define the authorized hosts:

```ruby
  set :host_authorization, permitted_hosts: ['example.com']
```

If this configuration directive is not specified, requests are rejected with a 403 response making the tests fail:

```
  1) FakeConfluentSchemaRegistryServer POST /subjects/:subject/versions returns the same schema ID when invoked with same schema and same subject
     Failure/Error: expected_id = JSON.parse(last_response.body).fetch('id')
     
     JSON::ParserError:
       unexpected token at 'Host not permitted'
     # ./spec/test/fake_confluent_schema_registry_server_spec.rb:13:in `block (3 levels) in <top (required)>'
```

With this pull request two new test servers are introduced with the proper authorization configuration directive, and the README file is updated to instruct users on how to use it in their own code bases.