### PR TITLE
Bump version to v1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.18.0
+
 - Add `compatibility_issues` method to `ConfluentSchemaRegistry` to debug compatibility issues between a schema versions for a given subject (#212)
 - Update tests to support `sinatra` version 4.1 that includes a new `host_authorization` parameter to permit only authorized requests
 

--- a/lib/avro_turf/version.rb
+++ b/lib/avro_turf/version.rb
@@ -1,3 +1,3 @@
 class AvroTurf
-  VERSION = "1.17.0"
+  VERSION = "1.18.0"
 end


### PR DESCRIPTION
This PR bumps the version to v.1.18.0, so we can take advantage of Sinatra `host_authorization` patch (and be able to upgrade to Sinatra 4).

Addresses: https://github.com/dasch/avro_turf/issues/216