### PR TITLE
Loosen excon dependency to allow 1.x

### DIFF
--- a/avro_turf.gemspec
+++ b/avro_turf.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "avro", ">= 1.11.3", "< 1.13"
-  spec.add_dependency "excon", "~> 0.104"
+  spec.add_dependency "excon", ">= 0.104", "< 2"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/spec/support/confluent_schema_registry_context.rb
+++ b/spec/support/confluent_schema_registry_context.rb
@@ -18,7 +18,7 @@ shared_examples_for "a confluent schema registry client" do |schema_context: nil
     {
       'Accept'=>'*/*',
       'Content-Type'=> AvroTurf::ConfluentSchemaRegistry::CONTENT_TYPE,
-      'Host'=> "#{URI.parse(registry_url).host}:80",
+      'Host'=> "#{URI.parse(registry_url).host}",
       'User-Agent'=> "excon/#{Excon::VERSION}"
     }
   end


### PR DESCRIPTION
Closes #214

This PR allows excon 1.x to be used with avro_turf, in addition to 0.104+.  I think this is the easiest way to unblock downstream users of avro_turf that want to be able to update excon without forcing those users to upgrade if for some reason they can't.