### PR TITLE
Stop overriding Excon's default connect_timeout when no argument is given

### DIFF
--- a/lib/avro_turf/confluent_schema_registry.rb
+++ b/lib/avro_turf/confluent_schema_registry.rb
@@ -28,8 +28,7 @@ class AvroTurf::ConfluentSchemaRegistry
       "Content-Type" => CONTENT_TYPE
     )
     headers[:proxy] = proxy unless proxy.nil?
-    @connection = Excon.new(
-      url,
+    params = {
       headers: headers,
       user: user,
       password: password,
@@ -39,8 +38,12 @@ class AvroTurf::ConfluentSchemaRegistry
       client_key_pass: client_key_pass,
       client_cert_data: client_cert_data,
       client_key_data: client_key_data,
-      connect_timeout: connect_timeout,
       resolv_resolver: resolv_resolver
+    }
+    params.merge!({ connect_timeout: connect_timeout }) if connect_timeout
+    @connection = Excon.new(
+      url,
+      params
     )
   end
 


### PR DESCRIPTION
When initializing `AvroTurf::ConfluentSchemaRegistry`, if `connect_timeout` is not explicitly specified, `connect_timeout: nil` is still passed internally to `Excon`.

This parameter is passed along the following path:

1. `AvroTurf::ConfluentSchemaRegistry` → passes `connect_timeout: nil` to `Excon.new`  
2. `Excon.new` → forwards the parameter to `Excon::Connection`  
   (ref: https://github.com/excon/excon/blob/449a443777342705373743f44694775dc7c22095/lib/excon.rb#L121-L132 )  
3. `Excon::Connection` → merges the provided options with default values  
   (ref: https://github.com/excon/excon/blob/449a443777342705373743f44694775dc7c22095/lib/excon/connection.rb#L65-L72 )

As a result, passing `connect_timeout: nil` overrides the default value of 60 seconds  
(ref: https://github.com/excon/excon/blob/449a443777342705373743f44694775dc7c22095/lib/excon/constants.rb#L141-L147 ).

This PR avoids that issue by not passing `connect_timeout` to Excon at all when the value is not explicitly provided, allowing Excon's default to be used properly.