### PR TITLE
Add retry_limit option for Schema Registry

### DIFF
--- a/lib/avro_turf/confluent_schema_registry.rb
+++ b/lib/avro_turf/confluent_schema_registry.rb
@@ -18,7 +18,8 @@ class AvroTurf::ConfluentSchemaRegistry
     client_key_data: nil,
     path_prefix: nil,
     connect_timeout: nil,
-    resolv_resolver: nil
+    resolv_resolver: nil,
+    retry_limit: nil
   )
     @path_prefix = path_prefix
     @schema_context_prefix = schema_context.nil? ? '' : ":.#{schema_context}:"
@@ -38,9 +39,12 @@ class AvroTurf::ConfluentSchemaRegistry
       client_key_pass: client_key_pass,
       client_cert_data: client_cert_data,
       client_key_data: client_key_data,
-      resolv_resolver: resolv_resolver
+      resolv_resolver: resolv_resolver,
+      connect_timeout: connect_timeout,
+      retry_limit: retry_limit
     }
-    params.merge!({ connect_timeout: connect_timeout }) if connect_timeout
+    # Remove nil params to allow Excon to use its default values
+    params.reject! { |_, v| v.nil? }
     @connection = Excon.new(
       url,
       params

--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -78,7 +78,8 @@ class AvroTurf
       client_cert_data: nil,
       client_key_data: nil,
       connect_timeout: nil,
-      resolv_resolver: nil
+      resolv_resolver: nil,
+      retry_limit: nil
     )
       @logger = logger || Logger.new($stderr)
       @namespace = namespace
@@ -99,7 +100,8 @@ class AvroTurf
           client_key_data: client_key_data,
           path_prefix: registry_path_prefix,
           connect_timeout: connect_timeout,
-          resolv_resolver: resolv_resolver
+          resolv_resolver: resolv_resolver,
+          retry_limit: retry_limit
         )
       )
       @schemas_by_id = {}

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -516,6 +516,30 @@ describe AvroTurf::Messaging do
     end
   end
 
+  context 'with a connect timeout' do
+    let(:avro) {
+      AvroTurf::Messaging.new(
+        registry_url: registry_url,
+        schemas_path: "spec/schemas",
+        logger: logger,
+        client_cert: client_cert,
+        client_key: client_key,
+        client_key_pass: client_key_pass,
+        retry_limit: 5
+      )
+    }
+
+    it_behaves_like "encoding and decoding with the schema from schema store"
+    it_behaves_like 'encoding and decoding with the schema from registry'
+    it_behaves_like 'encoding and decoding with the schema_id from registry'
+
+    it 'passes the connect timeout setting to Excon' do
+      expect(Excon).to receive(:new).with(anything, hash_including(retry_limit: 5)).and_call_original
+      avro
+    end
+  end
+
+
   context 'with a custom domain name resolver' do
     let(:resolv_resolver) { Resolv.new([Resolv::Hosts.new, Resolv::DNS.new(nameserver: ['127.0.0.1', '127.0.0.1'])]) }
     let(:avro) {


### PR DESCRIPTION
Add retry_limit option to ConfluentSchemaRegistry

This PR adds support for configuring the retry limit when connecting to the Confluent Schema Registry. The changes include:

- Added `retry_limit` parameter to `ConfluentSchemaRegistry` initialization
- Added `retry_limit` parameter to `AvroTurf::Messaging` initialization
- Updated the connection parameters to properly handle the retry limit setting
- Added test cases to verify the retry limit functionality
- Improved parameter handling by removing nil values to allow Excon to use its default values

The retry limit option allows users to control how many times the connection should be retried when encountering connection issues with the Schema Registry. This is particularly useful in environments where network reliability might be a concern.

Example usage:
```ruby
AvroTurf::Messaging.new(
  registry_url: "http://localhost:8081",
  retry_limit: 5
)
```
