### PR TITLE
Fix comment typo

### DIFF
--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -219,7 +219,7 @@ class AvroTurf
     end
 
     # Providing subject and version to determine the schema,
-    # which skips the auto registeration of schema on the schema registry.
+    # which skips the auto registration of schema on the schema registry.
     # Fetch the schema from registry with the provided subject name and version.
     def fetch_schema(subject:, version: 'latest')
       schema_data = @registry.subject_version(subject, version)


### PR DESCRIPTION
## Summary
- correct spelling of 'registration' in messaging comment

## Testing
- `bundle install`
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_686f7e6b7b2c8321ae23ab3baec8c221