### PR TITLE
Fix an error in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ require 'avro_turf/test/fake_confluent_schema_registry_server'
 require 'webmock/rspec'
 
 class AuthorizedFakeConfluentSchemaRegistryServer < FakeConfluentSchemaRegistryServer
-  set :host_authentication, permitted_hosts: ['registry.example.com']
+  set :host_authorization, permitted_hosts: ['registry.example.com']
 end
 
 # within an example


### PR DESCRIPTION
When setting permitted hosts in `FakeConfluentSchemaRegistryServer`, the correct call is `set :host_authorization`, not `set :host_authentication`.

See https://github.com/sinatra/sinatra?tab=readme-ov-file#available-settings