### PR TITLE
Use frozen strings in all files

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,5 +19,6 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
     - name: Build and test with RSpec
-      run: |
-        bundle exec rspec
+    - env:
+        RUBYOPT: '--enable=frozen-string-literal --debug=frozen-string-literal'
+      run: bundle exec rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Ensure the gem works with frozen strings.
+
 ## v1.19.0
 
 - Loosen excon dependency to allow 1.x (#220)

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in avro_turf.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 

--- a/avro_turf.gemspec
+++ b/avro_turf.gemspec
@@ -1,4 +1,6 @@
 # coding: utf-8
+# frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'avro_turf/version'
@@ -25,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.2"
-  spec.add_development_dependency "fakefs", "< 3"
+  spec.add_development_dependency "fakefs", "~> 3"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "sinatra"
   spec.add_development_dependency "json_spec"

--- a/lib/avro_turf.rb
+++ b/lib/avro_turf.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require 'avro-patches'
 rescue LoadError

--- a/lib/avro_turf/cached_confluent_schema_registry.rb
+++ b/lib/avro_turf/cached_confluent_schema_registry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'avro_turf/confluent_schema_registry'
 require 'avro_turf/in_memory_cache'
 require 'avro_turf/disk_cache'

--- a/lib/avro_turf/cached_schema_registry.rb
+++ b/lib/avro_turf/cached_schema_registry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'avro_turf/cached_confluent_schema_registry'
 
 # AvroTurf::CachedSchemaRegistry is deprecated and will be removed in a future release.

--- a/lib/avro_turf/confluent_schema_registry.rb
+++ b/lib/avro_turf/confluent_schema_registry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'excon'
 
 class AvroTurf::ConfluentSchemaRegistry

--- a/lib/avro_turf/core_ext.rb
+++ b/lib/avro_turf/core_ext.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'avro_turf/core_ext/string'
 require 'avro_turf/core_ext/numeric'
 require 'avro_turf/core_ext/enumerable'

--- a/lib/avro_turf/core_ext/date.rb
+++ b/lib/avro_turf/core_ext/date.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Date
   def as_avro
     self

--- a/lib/avro_turf/core_ext/enumerable.rb
+++ b/lib/avro_turf/core_ext/enumerable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Enumerable
   def as_avro
     map(&:as_avro)

--- a/lib/avro_turf/core_ext/false_class.rb
+++ b/lib/avro_turf/core_ext/false_class.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class FalseClass
   def as_avro
     self

--- a/lib/avro_turf/core_ext/hash.rb
+++ b/lib/avro_turf/core_ext/hash.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Hash
   def as_avro
     hsh = Hash.new

--- a/lib/avro_turf/core_ext/nil_class.rb
+++ b/lib/avro_turf/core_ext/nil_class.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class NilClass
   def as_avro
     self

--- a/lib/avro_turf/core_ext/numeric.rb
+++ b/lib/avro_turf/core_ext/numeric.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Numeric
   def as_avro
     self

--- a/lib/avro_turf/core_ext/string.rb
+++ b/lib/avro_turf/core_ext/string.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class String
   def as_avro
     self

--- a/lib/avro_turf/core_ext/symbol.rb
+++ b/lib/avro_turf/core_ext/symbol.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Symbol
   def as_avro
     to_s

--- a/lib/avro_turf/core_ext/time.rb
+++ b/lib/avro_turf/core_ext/time.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Time
   def as_avro
     iso8601

--- a/lib/avro_turf/core_ext/true_class.rb
+++ b/lib/avro_turf/core_ext/true_class.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TrueClass
   def as_avro
     self

--- a/lib/avro_turf/disk_cache.rb
+++ b/lib/avro_turf/disk_cache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # A cache for the CachedConfluentSchemaRegistry.
 # Extends the InMemoryCache to provide a write-thru to disk for persistent cache.
 class AvroTurf::DiskCache

--- a/lib/avro_turf/in_memory_cache.rb
+++ b/lib/avro_turf/in_memory_cache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # A cache for the CachedConfluentSchemaRegistry.
 # Simply stores the schemas and ids in in-memory hashes.
 class AvroTurf::InMemoryCache

--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'logger'
 require 'avro_turf'
 require 'avro_turf/schema_store'

--- a/lib/avro_turf/mutable_schema_store.rb
+++ b/lib/avro_turf/mutable_schema_store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'avro_turf/schema_store'
 
 class AvroTurf

--- a/lib/avro_turf/schema_registry.rb
+++ b/lib/avro_turf/schema_registry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'avro_turf/confluent_schema_registry'
 
 # AvroTurf::SchemaRegistry is deprecated and will be removed in a future release.

--- a/lib/avro_turf/schema_store.rb
+++ b/lib/avro_turf/schema_store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AvroTurf::SchemaStore
 
   def initialize(path: nil)

--- a/lib/avro_turf/schema_to_avro_patch.rb
+++ b/lib/avro_turf/schema_to_avro_patch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AvroTurf
   module AvroGemPatch
     module RecordSchema

--- a/lib/avro_turf/test/fake_confluent_schema_registry_server.rb
+++ b/lib/avro_turf/test/fake_confluent_schema_registry_server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'sinatra/base'
 
 class FakeConfluentSchemaRegistryServer < Sinatra::Base

--- a/lib/avro_turf/test/fake_prefixed_confluent_schema_registry_server.rb
+++ b/lib/avro_turf/test/fake_prefixed_confluent_schema_registry_server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'sinatra/base'
 
 class FakePrefixedConfluentSchemaRegistryServer < FakeConfluentSchemaRegistryServer

--- a/lib/avro_turf/test/fake_schema_registry_server.rb
+++ b/lib/avro_turf/test/fake_schema_registry_server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'avro_turf/test/fake_confluent_schema_registry_server'
 
 # FakeSchemaRegistryServer is deprecated and will be removed in a future release.

--- a/lib/avro_turf/version.rb
+++ b/lib/avro_turf/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AvroTurf
   VERSION = "1.19.0"
 end

--- a/perf/encoding_size.rb
+++ b/perf/encoding_size.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 # Measures the encoded size of messages of increasing size.
 

--- a/perf/encoding_speed.rb
+++ b/perf/encoding_speed.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 # Measures the time it takes to encode messages of increasing size.
 

--- a/spec/avro_turf_spec.rb
+++ b/spec/avro_turf_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe AvroTurf do
   let(:avro) { AvroTurf.new(schemas_path: "spec/schemas/") }
 

--- a/spec/cached_confluent_schema_registry_spec.rb
+++ b/spec/cached_confluent_schema_registry_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'webmock/rspec'
 require 'avro_turf/cached_confluent_schema_registry'
 require 'avro_turf/test/fake_confluent_schema_registry_server'

--- a/spec/confluent_schema_registry_spec.rb
+++ b/spec/confluent_schema_registry_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'webmock/rspec'
 require 'avro_turf/confluent_schema_registry'
 require 'avro_turf/test/fake_confluent_schema_registry_server'

--- a/spec/core_ext/date_spec.rb
+++ b/spec/core_ext/date_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Date, "#as_avro" do
   it "returns Date object describing the time" do
     date = Date.today

--- a/spec/core_ext/enumerable_spec.rb
+++ b/spec/core_ext/enumerable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Enumerable, "#as_avro" do
   it "returns an array" do
     expect(Set.new.as_avro).to eq []

--- a/spec/core_ext/false_class_spec.rb
+++ b/spec/core_ext/false_class_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe FalseClass, "#as_avro" do
   it "returns itself" do
     expect(false.as_avro).to eq false

--- a/spec/core_ext/hash_spec.rb
+++ b/spec/core_ext/hash_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Hash, "#as_avro" do
   it "coerces the keys and values to Avro" do
     x = double(as_avro: "x")

--- a/spec/core_ext/nil_class_spec.rb
+++ b/spec/core_ext/nil_class_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe NilClass, "#as_avro" do
   it "returns itself" do
     expect(nil.as_avro).to eq nil

--- a/spec/core_ext/numeric_spec.rb
+++ b/spec/core_ext/numeric_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Numeric, "#as_avro" do
   it "returns the number itself" do
     expect(42.as_avro).to eq 42

--- a/spec/core_ext/string_spec.rb
+++ b/spec/core_ext/string_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe String, "#as_avro" do
   it "returns itself" do
     expect("hello".as_avro).to eq "hello"

--- a/spec/core_ext/symbol_spec.rb
+++ b/spec/core_ext/symbol_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Symbol, "#as_avro" do
   it "returns the String representation of the Symbol" do
     expect(:hello.as_avro).to eq("hello")

--- a/spec/core_ext/time_spec.rb
+++ b/spec/core_ext/time_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Time, "#as_avro" do
   it "returns an ISO8601 string describing the time" do
     time = Time.now

--- a/spec/core_ext/true_class_spec.rb
+++ b/spec/core_ext/true_class_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe TrueClass, "#as_avro" do
   it "returns itself" do
     expect(true.as_avro).to eq true

--- a/spec/disk_cached_confluent_schema_registry_spec.rb
+++ b/spec/disk_cached_confluent_schema_registry_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'webmock/rspec'
 require 'avro_turf/cached_confluent_schema_registry'
 require 'avro_turf/test/fake_confluent_schema_registry_server'

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'webmock/rspec'
 require 'avro_turf/messaging'
 

--- a/spec/schema_store_spec.rb
+++ b/spec/schema_store_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'avro_turf/schema_store'
 
 describe AvroTurf::SchemaStore do

--- a/spec/schema_to_avro_patch_spec.rb
+++ b/spec/schema_to_avro_patch_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'webmock/rspec'
 
 # This spec verifies the monkey-patch that we have to apply until the avro

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/setup'
 require 'logger'
 require 'json_spec'

--- a/spec/support/authorized_fake_confluent_schema_registry_server.rb
+++ b/spec/support/authorized_fake_confluent_schema_registry_server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'avro_turf/test/fake_confluent_schema_registry_server'
 
 class AuthorizedFakeConfluentSchemaRegistryServer < FakeConfluentSchemaRegistryServer

--- a/spec/support/authorized_fake_prefixed_confluent_schema_registry_server.rb
+++ b/spec/support/authorized_fake_prefixed_confluent_schema_registry_server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'avro_turf/test/fake_prefixed_confluent_schema_registry_server'
 
 class AuthorizedFakePrefixedConfluentSchemaRegistryServer < FakePrefixedConfluentSchemaRegistryServer

--- a/spec/support/confluent_schema_registry_context.rb
+++ b/spec/support/confluent_schema_registry_context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This shared example expects a registry variable to be defined
 # with an instance of the registry class being tested.
 shared_examples_for "a confluent schema registry client" do |schema_context: nil|

--- a/spec/test/fake_confluent_schema_registry_server_spec.rb
+++ b/spec/test/fake_confluent_schema_registry_server_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rack/test'
 
 describe FakeConfluentSchemaRegistryServer do


### PR DESCRIPTION
- Use the `frozen_string_literal: true` header in all files.
- Use a newer (frozen strings compatible) version of fakefs in tests.
- On CI, globally enable the `frozen-string-literal` setting.
