### PR TITLE
CI: Less noise, etc.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,10 +9,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [3.0, 3.1, 3.2, 3.3]
+        ruby: ["3.0", 3.1, 3.2, 3.3]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Set up Ruby ${{ matrix.ruby }}
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", 3.1, 3.2, 3.3]
+        ruby: ["3.0", 3.1, 3.2, 3.3, 3.4]
 
     steps:
     - uses: actions/checkout@v5

--- a/spec/confluent_schema_registry_spec.rb
+++ b/spec/confluent_schema_registry_spec.rb
@@ -29,6 +29,7 @@ describe AvroTurf::ConfluentSchemaRegistry do
       let(:registry) {
         described_class.new(
           registry_url,
+          logger: logger,
           user: user,
           password: password,
         )
@@ -41,6 +42,7 @@ describe AvroTurf::ConfluentSchemaRegistry do
       let(:registry) {
         described_class.new(
           registry_url,
+          logger: logger,
           user: user,
           password: password,
           connect_timeout: connect_timeout
@@ -54,6 +56,7 @@ describe AvroTurf::ConfluentSchemaRegistry do
       let(:registry) {
         described_class.new(
           registry_url,
+          logger: logger,
           schema_context: 'other',
           user: user,
           password: password,


### PR DESCRIPTION
The spec output included a lot of unwanted noise from the logger. Passing in the null logger takes care of it.

As mentioned in #183, in the CI config, `3.0` needs to be quoted. Since b30f262e2afea2ca2f9ff841b93905c2f0a3498d we have not been testing with Ruby 3.0, but instead with the latest version of Ruby 3.x.