### PR TITLE
Bump version to 1.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Memoize parsed schemas to improve encoding performance when using `AvroTurf::Messaging` (#206)
 
+## v1.20.1
+
+- Remove `sinatra` as a development dependency (#237)
+
 ## v1.20.0
 
 - Add support for client certificate chains via `client_chain` and `client_chain_data` parameters (#233)

--- a/lib/avro_turf/version.rb
+++ b/lib/avro_turf/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class AvroTurf
-  VERSION = "1.20.0"
+  VERSION = "1.20.1"
 end


### PR DESCRIPTION
https://github.com/dasch/avro_turf/pull/237 merge failed to push gem to rubygems.org ( https://github.com/dasch/avro_turf/actions/runs/19824029716/job/56792832311 ) as the version 1.20.0 already existed.

Bump version to 1.20.1 ( and updated the CHANGELOG ) to fix it